### PR TITLE
Add LLM image captioning and multimodal support

### DIFF
--- a/curator-docs/reddit-locallama-caption.yaml
+++ b/curator-docs/reddit-locallama-caption.yaml
@@ -60,8 +60,7 @@ workflow:
           include_comment_images: false
           caption:
             model: Qwen/Qwen3-VL-30B-A3B-Instruct-FP8
-            system_template: imageCaptionSystem
-            prompt_template: imageCaptionPrompt
+            template: imageCaption
 
   post_summary:
     - llm:
@@ -81,8 +80,7 @@ workflow:
           include_comment_images: false
           caption:
             model: Qwen/Qwen3-VL-30B-A3B-Instruct-FP8
-            system_template: imageCaptionSystem
-            prompt_template: imageCaptionPrompt
+            template: imageCaption
 
     - markdown:
         name: markdown_to_html_post_sum
@@ -113,15 +111,11 @@ workflow:
         subject: "Daily AI Research"
 
 templates:
-  - id: imageCaptionSystem
+  - id: imageCaption
     system_template: |-
       You describe images precisely for downstream LLM prompts.
       You will also be given brief post context (title/body). Use it to interpret the image and focus the caption on what matters for that post.
       Return ONLY a short caption (1-3 sentences), no markdown.
-    template: "--"
-
-  - id: imageCaptionPrompt
-    system_template: "--"
     template: |-
       Post context:
       Title: {{ .Post.Title }}

--- a/curator-docs/reddit-locallama-caption.yaml
+++ b/curator-docs/reddit-locallama-caption.yaml
@@ -1,0 +1,333 @@
+workflow:
+  name: "AI Research Intelligence (Caption/OCR Example)"
+  # version: "1.0" # optional
+  max_concurrency: 20
+
+  trigger:
+    - cron:
+        schedule: "0 0 * * *" # midnight UTC
+        # timezone: "UTC"     # optional
+
+  sources:
+    - reddit:
+        subreddits: ["LocalLLaMA"]
+        include_comments: true
+        include_web: true
+        include_images: true
+        limit: 25          # optional
+        sort: "hot"        # optional
+        time_filter: "day" # optional
+        min_score: 10      # optional
+        snapshot:
+          # snapshot: true
+          restore: true
+          path: "snapshots/reddit.json"
+
+  quality:
+    - quality_rule:
+        name: min_comments
+        rule: "comments.count > 5"
+        actionType: pass_drop
+        result: drop
+        snapshot:
+          # snapshot: true
+          restore: true
+          path: "snapshots/quality-rule.json"
+    - llm:
+        name: is_relevant
+        prompt_template: isRelevantTemplateCaption
+        evaluations:
+          - "Contains specific technical details or specifications"
+          - "Explains the significance and impact of the development"
+          - "Includes performance metrics, benchmarks, or comparisons"
+          - "Discusses novel approaches or techniques"
+          - "Valuable insights into commercial applications of AI technology"
+          - "New model releases or updates from major AI labs"
+          - "Innovative use cases or applications of LLMs"
+        exclusions:
+          - "Content entirely unrelated to AI/ML technology"
+          - "Questions that would be better suited for tech support"
+          - "Random complaints without technical content"
+          - "Humor posts"
+          - "Personal blog-style posts"
+          - "Career advice or job postings"
+        action_type: pass_drop
+        threshold: 0.5 # optional
+        images:
+          enabled: true
+          mode: caption
+          max_images: 4
+          include_comment_images: false
+          caption:
+            model: Qwen/Qwen3-VL-30B-A3B-Instruct-FP8
+            system_template: imageCaptionSystem
+            prompt_template: imageCaptionPrompt
+
+  post_summary:
+    - llm:
+        name: post_sum
+        type: llm
+        context: post
+        prompt_template: postSummaryTemplateCaption
+        params:
+          interests:
+            - "New LLM models, runners or other infrastructure being released or open sourced"
+            - "Big AI lab news (OpenAI, Anthropic, DeepSeek, Qwen etc.)"
+            - "Security news"
+        images:
+          enabled: true
+          mode: caption
+          max_images: 4
+          include_comment_images: false
+          caption:
+            model: Qwen/Qwen3-VL-30B-A3B-Instruct-FP8
+            system_template: imageCaptionSystem
+            prompt_template: imageCaptionPrompt
+
+    - markdown:
+        name: markdown_to_html_post_sum
+        type: markdown
+        context: post
+
+  run_summary:
+    - llm:
+        name: full_sum
+        type: llm
+        context: flow
+        prompt_template: fullSummaryTemplate
+        params:
+          focus:
+            - "Major advances in model architecture or capabilities"
+            - "Emerging trends in open-source LLM development"
+            - "Notable performance breakthroughs"
+            - "Industry impact and adoption patterns"
+    - markdown:
+        name: markdown_to_html_sum
+        type: markdown
+        context: "flow"
+
+  output:
+    - email:
+        template: emailTemplate
+        to: brandon@bdmd.com.au
+        subject: "Daily AI Research"
+
+templates:
+  - id: imageCaptionSystem
+    system_template: |-
+      You describe images precisely for downstream LLM prompts.
+      You will also be given brief post context (title/body). Use it to interpret the image and focus the caption on what matters for that post.
+      Return ONLY a short caption (1-3 sentences), no markdown.
+    template: "--"
+
+  - id: imageCaptionPrompt
+    system_template: "--"
+    template: |-
+      Post context:
+      Title: {{ .Post.Title }}
+      URL: {{ .Post.URL }}
+      Body (may be empty/truncated):
+      {{ .Post.Content }}
+
+      Describe the image focusing on technical details (charts, tables, code, UI, metrics).
+      If there is a chart, extract key numbers and units.
+      Image URL: {{ .Image.URL }}
+
+  - id: isRelevantTemplateCaption
+    system_template: |-
+      You are a strict relevance/quality evaluator.
+
+      Some posts include images. A separate caption/OCR step may have populated ImageBlocks[].Summary.
+      Use those image summaries as evidence when post text is sparse.
+
+      Evaluate the following post and output ONLY valid JSON with this exact shape:
+      {"score": <number 0..1>, "reason": <string>}
+
+      Scoring guidance:
+      - 0.0 = completely irrelevant / low-signal
+      - 1.0 = extremely relevant / high-signal
+
+      Positive evaluation criteria (score higher when these apply):
+      {{- range .Evaluations }}
+      - {{ . }}
+      {{- end }}
+
+      Exclusion criteria (score near 0 when these apply):
+      {{- range .Exclusions }}
+      - {{ . }}
+      {{- end }}
+
+      Reason should be a single sentence of 25 words or less.
+
+      Return ONLY the JSON object. No markdown, no code fences.
+    template: |-
+      -----USER CONTENT START-----
+      Post:
+      Title: {{ .Title }}
+      URL: {{ .URL }}
+      Author: {{ .Author }}
+      CreatedAt: {{ .CreatedAt }}
+
+      Content:
+      {{ .Content }}
+
+      Web Content:
+      {{- range .WebBlocks }}
+      - {{ .URL }}
+        {{ .Page }}
+      {{- end }}
+
+      Image summaries (if any):
+      {{- if .ImageBlocks }}
+      {{- range .ImageBlocks }}
+      - {{ .URL }}
+        {{- if .WasSummarised }}
+        {{ .Summary }}
+        {{- else }}
+        (not captioned)
+        {{- end }}
+      {{- end }}
+      {{- else }}
+      (none)
+      {{- end }}
+      -----USER CONTENT END-----
+
+  - id: postSummaryTemplateCaption
+    system_template: |-
+      You are an expert technical analyst.
+
+      Some posts include images. A separate caption/OCR step may have populated ImageBlocks[].Summary.
+      Use those image summaries as evidence when post text is sparse.
+
+      Write a concise summary of the following post. Focus on the reader interests.
+      Keep it factual, and include concrete details (numbers, model names, benchmarks) when present.
+      When comments are present, summarise the community response.
+
+      Reader interests:
+      {{- range (index .Params "interests") }}
+      - {{ . }}
+      {{- end }}
+
+      Output format:
+      - 3-6 bullet points
+      - then "Why it matters:" (1-2 sentences)
+      - then "Community response:" (1-2 sentences if comments are provided)
+      - then "Key entities:" (comma-separated list)
+
+    template: |-
+      -----USER CONTENT START-----
+      Post:
+      Title: {{ .Title }}
+      URL: {{ .URL }}
+      Author: {{ .Author }}
+
+      Content:
+      {{ .Content }}
+
+      Comments (optional signal; {{ len .Comments }}):
+      {{- range $i, $c := .Comments }}
+      - {{ $c.Author }}: {{ $c.Content }}
+      {{- end }}
+
+      Linked URLs:
+      {{- range .WebBlocks }}
+      - {{ .URL }}
+        {{ .Page }}
+      {{- end }}
+
+      Image summaries (if any):
+      {{- if .ImageBlocks }}
+      {{- range .ImageBlocks }}
+      - {{ .URL }}
+        {{- if .WasSummarised }}
+        {{ .Summary }}
+        {{- else }}
+        (not captioned)
+        {{- end }}
+      {{- end }}
+      {{- else }}
+      (none)
+      {{- end }}
+      -----USER CONTENT END-----
+
+  - id: fullSummaryTemplate
+    system_template: |-
+      You are writing an aggregate digest across multiple posts.
+
+      Produce an executive summary, then group notable items.
+
+      Include an:
+      - Executive summary, focused on 4-8 bullet points
+      - Notable Items, pick 5 most relevant items to the focus area, bulleted, include post title + 1 sentence
+
+      Focus areas:
+      {{- range (index .Params "focus") }}
+      - {{ . }}
+      {{- end }}
+
+      Output format:
+      # Executive summary
+      # Notable items
+
+    template: |-
+      There are {{ len .Blocks }} posts.
+
+      Posts:
+      {{- range $i, $p := .Blocks }}
+      ---
+      Title: {{ $p.Title }}
+      URL: {{ $p.URL }}
+      Author: {{ $p.Author }}
+      Post summary (if present): {{- if $p.Summary }}
+      {{ $p.Summary.Summary }}
+      {{- else }}
+      (none)
+      {{- end }}
+      {{- end }}
+
+  - id: emailTemplate
+    system_template: "--" # Email is still considered a prompt template right now
+    template: |-
+      <!doctype html>
+      <html>
+        <body style="margin:0;padding:0;background:#ffffff;">
+          <div style="max-width:720px;margin:0 auto;padding:16px;font-family:Arial,Helvetica,sans-serif;color:#111;line-height:1.4;">
+            <h1 style="margin:0 0 12px 0;font-size:22px;">Daily AI Research Digest</h1>
+
+            {{- if .RunSummary }}
+            {{- .RunSummary.HTML }}
+            {{- end }}
+
+            <h2 style="margin:16px 0 8px 0;font-size:16px;">Posts ({{ len .Blocks }})</h2>
+
+            {{- range .Blocks }}
+            <div style="padding:12px 0;border-top:1px solid #e5e5e5;">
+              <div style="font-size:15px;font-weight:700;margin:0 0 4px 0;">
+                <a href="{{ .URL }}" style="color:#111;text-decoration:underline;">{{ .Title }}</a>
+              </div>
+              <div style="font-size:12px;color:#666;margin:0 0 8px 0;">
+                <a href="{{ .URL }}" style="color:#666;text-decoration:none;">{{ .URL }}</a>
+              </div>
+              <div style="font-size:13px;margin:0;">
+                {{- if .Summary }}
+                {{ .Summary.HTML }}
+                {{- else }}
+                (no summary)
+                {{- end }}
+              </div>
+
+              {{- if .WebBlocks }}
+              <div style="margin:10px 0 0 0;font-size:13px;">
+                <div style="font-weight:700;margin:0 0 4px 0;">Links</div>
+                <ul style="margin:0;padding-left:18px;">
+                  {{- range .WebBlocks }}
+                  <li style="margin:0 0 4px 0;"><a href="{{ .URL }}" style="color:#111;text-decoration:underline;">{{ .URL }}</a></li>
+                  {{- end }}
+                </ul>
+              </div>
+              {{- end }}
+            </div>
+            {{- end }}
+          </div>
+        </body>
+      </html>

--- a/curator-docs/reddit-locallama-multimodal.yaml
+++ b/curator-docs/reddit-locallama-multimodal.yaml
@@ -1,0 +1,282 @@
+workflow:
+  name: "AI Research Intelligence (Multimodal Example)"
+  # version: "1.0" # optional
+  max_concurrency: 20
+
+  trigger:
+    - cron:
+        schedule: "0 0 * * *" # midnight UTC
+        # timezone: "UTC"     # optional
+
+  sources:
+    - reddit:
+        subreddits: ["LocalLLaMA"]
+        include_comments: true
+        include_web: true
+        include_images: true
+        limit: 25          # optional
+        sort: "hot"        # optional
+        time_filter: "day" # optional
+        min_score: 10      # optional
+        snapshot:
+          # snapshot: true
+          restore: true
+          path: "snapshots/reddit.json"
+
+  quality:
+    - quality_rule:
+        name: min_comments
+        rule: "comments.count > 5"
+        actionType: pass_drop
+        result: drop
+        snapshot:
+          # snapshot: true
+          restore: true
+          path: "snapshots/quality-rule.json"
+    - llm:
+        name: is_relevant
+        prompt_template: isRelevantTemplateMultimodal
+        evaluations:
+          - "Contains specific technical details or specifications"
+          - "Explains the significance and impact of the development"
+          - "Includes performance metrics, benchmarks, or comparisons"
+          - "Discusses novel approaches or techniques"
+          - "Valuable insights into commercial applications of AI technology"
+          - "New model releases or updates from major AI labs"
+          - "Innovative use cases or applications of LLMs"
+        exclusions:
+          - "Content entirely unrelated to AI/ML technology"
+          - "Questions that would be better suited for tech support"
+          - "Random complaints without technical content"
+          - "Humor posts"
+          - "Personal blog-style posts"
+          - "Career advice or job postings"
+        action_type: pass_drop
+        threshold: 0.5 # optional
+        images:
+          enabled: true
+          mode: multimodal
+          max_images: 4
+          include_comment_images: false
+
+  post_summary:
+    - llm:
+        name: post_sum
+        type: llm
+        context: post
+        prompt_template: postSummaryTemplateMultimodal
+        params:
+          interests:
+            - "New LLM models, runners or other infrastructure being released or open sourced"
+            - "Big AI lab news (OpenAI, Anthropic, DeepSeek, Qwen etc.)"
+            - "Security news"
+        images:
+          enabled: true
+          mode: multimodal
+          max_images: 4
+          include_comment_images: false
+
+    - markdown:
+        name: markdown_to_html_post_sum
+        type: markdown
+        context: post
+
+  run_summary:
+    - llm:
+        name: full_sum
+        type: llm
+        context: flow
+        prompt_template: fullSummaryTemplate
+        params:
+          focus:
+            - "Major advances in model architecture or capabilities"
+            - "Emerging trends in open-source LLM development"
+            - "Notable performance breakthroughs"
+            - "Industry impact and adoption patterns"
+    - markdown:
+        name: markdown_to_html_sum
+        type: markdown
+        context: "flow"
+
+  output:
+    - email:
+        template: emailTemplate
+        to: brandon@bdmd.com.au
+        subject: "Daily AI Research"
+
+templates:
+  - id: isRelevantTemplateMultimodal
+    system_template: |-
+      You are a strict relevance/quality evaluator.
+
+      You may be given post text plus one or more images attached as multimodal inputs.
+      Use images as primary evidence when the post text is sparse. If charts/tables are present, extract key numbers and units.
+
+      Evaluate the post and output ONLY valid JSON with this exact shape:
+      {"score": <number 0..1>, "reason": <string>}
+
+      Scoring guidance:
+      - 0.0 = completely irrelevant / low-signal
+      - 1.0 = extremely relevant / high-signal
+
+      Positive evaluation criteria (score higher when these apply):
+      {{- range .Evaluations }}
+      - {{ . }}
+      {{- end }}
+
+      Exclusion criteria (score near 0 when these apply):
+      {{- range .Exclusions }}
+      - {{ . }}
+      {{- end }}
+
+      Reason should be a single sentence of 25 words or less.
+
+      Return ONLY the JSON object. No markdown, no code fences.
+    template: |-
+      -----USER CONTENT START-----
+      Post:
+      Title: {{ .Title }}
+      URL: {{ .URL }}
+      Author: {{ .Author }}
+      CreatedAt: {{ .CreatedAt }}
+
+      Content:
+      {{ .Content }}
+
+      Web Content:
+      {{- range .WebBlocks }}
+      - {{ .URL }}
+        {{ .Page }}
+      {{- end }}
+
+      Images attached: {{ len .ImageBlocks }}
+      -----USER CONTENT END-----
+
+  - id: postSummaryTemplateMultimodal
+    system_template: |-
+      You are an expert technical analyst.
+
+      You may be given post text plus one or more images attached as multimodal inputs.
+      Use images as primary evidence when the post text is sparse. If charts/tables are present, extract key numbers and units.
+
+      Write a concise summary of the post. Focus on the reader interests.
+      Keep it factual, and include concrete details (numbers, model names, benchmarks) when present.
+      When comments are present, summarise the community response.
+
+      Reader interests:
+      {{- range (index .Params "interests") }}
+      - {{ . }}
+      {{- end }}
+
+      Output format:
+      - 3-6 bullet points
+      - then "Why it matters:" (1-2 sentences)
+      - then "Community response:" (1-2 sentences if comments are provided)
+      - then "Key entities:" (comma-separated list)
+
+    template: |-
+      -----USER CONTENT START-----
+      Post:
+      Title: {{ .Title }}
+      URL: {{ .URL }}
+      Author: {{ .Author }}
+
+      Content:
+      {{ .Content }}
+
+      Comments (optional signal; {{ len .Comments }}):
+      {{- range $i, $c := .Comments }}
+      - {{ $c.Author }}: {{ $c.Content }}
+      {{- end }}
+
+      Linked URLs:
+      {{- range .WebBlocks }}
+      - {{ .URL }}
+        {{ .Page }}
+      {{- end }}
+
+      Images attached: {{ len .ImageBlocks }}
+      -----USER CONTENT END-----
+
+  - id: fullSummaryTemplate
+    system_template: |-
+      You are writing an aggregate digest across multiple posts.
+
+      Produce an executive summary, then group notable items.
+
+      Include an:
+      - Executive summary, focused on 4-8 bullet points
+      - Notable Items, pick 5 most relevant items to the focus area, bulleted, include post title + 1 sentence
+
+      Focus areas:
+      {{- range (index .Params "focus") }}
+      - {{ . }}
+      {{- end }}
+
+      Output format:
+      # Executive summary
+      # Notable items
+
+    template: |-
+      There are {{ len .Blocks }} posts.
+
+      Posts:
+      {{- range $i, $p := .Blocks }}
+      ---
+      Title: {{ $p.Title }}
+      URL: {{ $p.URL }}
+      Author: {{ $p.Author }}
+      Post summary (if present): {{- if $p.Summary }}
+      {{ $p.Summary.Summary }}
+      {{- else }}
+      (none)
+      {{- end }}
+      {{- end }}
+
+  - id: emailTemplate
+    system_template: "--" # Email is still considered a prompt template right now
+    template: |-
+      <!doctype html>
+      <html>
+        <body style="margin:0;padding:0;background:#ffffff;">
+          <div style="max-width:720px;margin:0 auto;padding:16px;font-family:Arial,Helvetica,sans-serif;color:#111;line-height:1.4;">
+            <h1 style="margin:0 0 12px 0;font-size:22px;">Daily AI Research Digest</h1>
+
+            {{- if .RunSummary }}
+            {{- .RunSummary.HTML }}
+            {{- end }}
+
+            <h2 style="margin:16px 0 8px 0;font-size:16px;">Posts ({{ len .Blocks }})</h2>
+
+            {{- range .Blocks }}
+            <div style="padding:12px 0;border-top:1px solid #e5e5e5;">
+              <div style="font-size:15px;font-weight:700;margin:0 0 4px 0;">
+                <a href="{{ .URL }}" style="color:#111;text-decoration:underline;">{{ .Title }}</a>
+              </div>
+              <div style="font-size:12px;color:#666;margin:0 0 8px 0;">
+                <a href="{{ .URL }}" style="color:#666;text-decoration:none;">{{ .URL }}</a>
+              </div>
+              <div style="font-size:13px;margin:0;">
+                {{- if .Summary }}
+                {{ .Summary.HTML }}
+                {{- else }}
+                (no summary)
+                {{- end }}
+              </div>
+
+              {{- if .WebBlocks }}
+              <div style="margin:10px 0 0 0;font-size:13px;">
+                <div style="font-weight:700;margin:0 0 4px 0;">Links</div>
+                <ul style="margin:0;padding-left:18px;">
+                  {{- range .WebBlocks }}
+                  <li style="margin:0 0 4px 0;"><a href="{{ .URL }}" style="color:#111;text-decoration:underline;">{{ .URL }}</a></li>
+                  {{- end }}
+                </ul>
+              </div>
+              {{- end }}
+            </div>
+            {{- end }}
+          </div>
+        </body>
+      </html>
+

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.25.5
 
 require (
 	github.com/expr-lang/expr v1.17.7
+	github.com/gabriel-vasile/mimetype v1.4.6
 	github.com/mmcdole/gofeed v1.3.0
 	github.com/openai/openai-go v1.12.0
 	github.com/robfig/cron/v3 v3.0.1

--- a/go.sum
+++ b/go.sum
@@ -10,6 +10,7 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/expr-lang/expr v1.17.7 h1:Q0xY/e/2aCIp8g9s/LGvMDCC5PxYlvHgDZRQ4y16JX8=
 github.com/expr-lang/expr v1.17.7/go.mod h1:8/vRC7+7HBzESEqt5kKpYXxrxkr31SaO8r40VO/1IT4=
+github.com/gabriel-vasile/mimetype v1.4.6/go.mod h1:JX1qVKqZd40hUPpAfiNTe0Sne7hdfKSbOqqmkq8GCXc=
 github.com/go-logr/logr v1.2.2/go.mod h1:jdQByPbusPIv2/zmleS9BjJVeZ6kBagPoEUsqbVz/1A=
 github.com/go-logr/logr v1.4.2 h1:6pFjapn8bFcIbiKo3XT4j/BhANplGihG6tvd+8rYgrY=
 github.com/go-logr/logr v1.4.2/go.mod h1:9T104GzyrTigFIr8wt5mBrctHMim0Nb2HLGrmQ40KvY=

--- a/go.sum
+++ b/go.sum
@@ -10,6 +10,7 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/expr-lang/expr v1.17.7 h1:Q0xY/e/2aCIp8g9s/LGvMDCC5PxYlvHgDZRQ4y16JX8=
 github.com/expr-lang/expr v1.17.7/go.mod h1:8/vRC7+7HBzESEqt5kKpYXxrxkr31SaO8r40VO/1IT4=
+github.com/gabriel-vasile/mimetype v1.4.6 h1:3+PzJTKLkvgjeTbts6msPJt4DixhT4YtFNf1gtGe3zc=
 github.com/gabriel-vasile/mimetype v1.4.6/go.mod h1:JX1qVKqZd40hUPpAfiNTe0Sne7hdfKSbOqqmkq8GCXc=
 github.com/go-logr/logr v1.2.2/go.mod h1:jdQByPbusPIv2/zmleS9BjJVeZ6kBagPoEUsqbVz/1A=
 github.com/go-logr/logr v1.4.2 h1:6pFjapn8bFcIbiKo3XT4j/BhANplGihG6tvd+8rYgrY=

--- a/internal/config/schema.go
+++ b/internal/config/schema.go
@@ -496,7 +496,7 @@ func (d *CuratorDocument) resolveTemplateReferences() error {
 			q.PromptTemplate = resolved.Template
 		}
 		if q.Images != nil && q.Images.Caption != nil {
-			if resolved, ok := byID[q.Images.Caption.PromptTemplate]; ok {
+			if resolved, ok := byID[q.Images.Caption.Template]; ok {
 				q.Images.Caption.SystemTemplate = resolved.SystemTemplate
 				q.Images.Caption.PromptTemplate = resolved.Template
 			}
@@ -514,7 +514,7 @@ func (d *CuratorDocument) resolveTemplateReferences() error {
 			s.PromptTemplate = resolved.Template
 		}
 		if s.Images != nil && s.Images.Caption != nil {
-			if resolved, ok := byID[s.Images.Caption.PromptTemplate]; ok {
+			if resolved, ok := byID[s.Images.Caption.Template]; ok {
 				s.Images.Caption.SystemTemplate = resolved.SystemTemplate
 				s.Images.Caption.PromptTemplate = resolved.Template
 			}
@@ -532,7 +532,7 @@ func (d *CuratorDocument) resolveTemplateReferences() error {
 			s.PromptTemplate = resolved.Template
 		}
 		if s.Images != nil && s.Images.Caption != nil {
-			if resolved, ok := byID[s.Images.Caption.PromptTemplate]; ok {
+			if resolved, ok := byID[s.Images.Caption.Template]; ok {
 				s.Images.Caption.SystemTemplate = resolved.SystemTemplate
 				s.Images.Caption.PromptTemplate = resolved.Template
 			}

--- a/internal/config/schema.go
+++ b/internal/config/schema.go
@@ -143,9 +143,13 @@ type LLMImages struct {
 }
 
 type LLMImageCaption struct {
-	Model          string   `yaml:"model,omitempty"`
-	SystemTemplate string   `yaml:"system_template"`
-	PromptTemplate string   `yaml:"prompt_template"`
+	Model string `yaml:"model,omitempty"`
+	// This is the reference to the template that's actually used in the doc
+	Template string `yaml:"template,omitempty"`
+	// These two are for the resolved templates
+	SystemTemplate string `yaml:"system_template"`
+	PromptTemplate string `yaml:"prompt_template"`
+
 	Temperature    *float64 `yaml:"temperature,omitempty"`
 	MaxConcurrency int      `yaml:"max_concurrency,omitempty"`
 }

--- a/internal/config/schema_test.go
+++ b/internal/config/schema_test.go
@@ -353,6 +353,59 @@ func TestValidation(t *testing.T) {
 			errorMsg:    "output configuration is required",
 		},
 		{
+			name: "Images enabled without mode",
+			doc: CuratorDocument{
+				Workflow: Workflow{
+					Name:    "Test",
+					Trigger: []TriggerConfig{{Cron: &CronTrigger{Schedule: "* * * * *"}}},
+					Sources: []SourceConfig{{Reddit: &RedditSource{Subreddits: []string{"test"}}}},
+					Quality: []QualityConfig{{LLM: &LLMQuality{
+						Name:           "quality_check",
+						PromptTemplate: "quality_template",
+						ActionType:     "pass_drop",
+						Images:         &LLMImages{Enabled: true},
+					}}},
+					Output: []OutputConfig{{Email: &EmailOutput{
+						Template: "test",
+						To:       "test@test.com",
+						From:     "noreply@test.com",
+						Subject:  "Test Subject",
+					}}},
+				},
+			},
+			expectError: true,
+			errorMsg:    "images.mode is required",
+		},
+		{
+			name: "Caption mode missing templates",
+			doc: CuratorDocument{
+				Workflow: Workflow{
+					Name:    "Test",
+					Trigger: []TriggerConfig{{Cron: &CronTrigger{Schedule: "* * * * *"}}},
+					Sources: []SourceConfig{{Reddit: &RedditSource{Subreddits: []string{"test"}}}},
+					PostSummary: []SummaryConfig{{LLM: &LLMSummary{
+						Name:           "post_sum",
+						Type:           "llm",
+						Context:        "post",
+						PromptTemplate: "summary_template",
+						Images: &LLMImages{
+							Enabled: true,
+							Mode:    ImageModeCaption,
+							Caption: &LLMImageCaption{},
+						},
+					}}},
+					Output: []OutputConfig{{Email: &EmailOutput{
+						Template: "test",
+						To:       "test@test.com",
+						From:     "noreply@test.com",
+						Subject:  "Test Subject",
+					}}},
+				},
+			},
+			expectError: true,
+			errorMsg:    "images.caption system_template and prompt_template are required",
+		},
+		{
 			name: "RSS source missing feeds",
 			doc: CuratorDocument{
 				Workflow: Workflow{

--- a/internal/config/template_typecheck.go
+++ b/internal/config/template_typecheck.go
@@ -10,6 +10,9 @@ import (
 	"github.com/bakkerme/curator-ai/internal/core"
 )
 
+// validateTemplateTypes checks all templates in the CuratorDocument for type correctness
+// by attempting to parse and execute them with sample data. It returns an error if any
+// template fails to parse or execute.
 func (d *CuratorDocument) validateTemplateTypes() error {
 	post := samplePostBlockForTemplateValidation()
 	run := sampleRunSummaryForTemplateValidation()
@@ -191,6 +194,7 @@ func typeCheckHTMLTemplate(name, templateText string, data any) error {
 	return tmpl.Execute(&buf, data)
 }
 
+// The sample block needs to contain a fully formed PostBlock with all possible fields populated
 func samplePostBlockForTemplateValidation() *core.PostBlock {
 	now := time.Unix(0, 0).UTC()
 	return &core.PostBlock{

--- a/internal/config/template_typecheck.go
+++ b/internal/config/template_typecheck.go
@@ -40,6 +40,25 @@ func (d *CuratorDocument) validateTemplateTypes() error {
 				return fmt.Errorf("quality %d (%s): prompt_template type check failed: %w", i, q.Name, err)
 			}
 		}
+		if q.Images != nil && q.Images.Caption != nil {
+			captionData := struct {
+				Post  *core.PostBlock
+				Image *core.ImageBlock
+			}{
+				Post:  post,
+				Image: &post.ImageBlocks[0],
+			}
+			if q.Images.Caption.SystemTemplate != "" {
+				if err := typeCheckTextTemplate(fmt.Sprintf("quality[%d].images.caption.system_template", i), q.Images.Caption.SystemTemplate, captionData); err != nil {
+					return fmt.Errorf("quality %d (%s): images.caption.system_template type check failed: %w", i, q.Name, err)
+				}
+			}
+			if q.Images.Caption.PromptTemplate != "" {
+				if err := typeCheckTextTemplate(fmt.Sprintf("quality[%d].images.caption.prompt_template", i), q.Images.Caption.PromptTemplate, captionData); err != nil {
+					return fmt.Errorf("quality %d (%s): images.caption.prompt_template type check failed: %w", i, q.Name, err)
+				}
+			}
+		}
 	}
 
 	// Post summary LLM templates.
@@ -65,6 +84,25 @@ func (d *CuratorDocument) validateTemplateTypes() error {
 				return fmt.Errorf("post_summary %d (%s): prompt_template type check failed: %w", i, s.Name, err)
 			}
 		}
+		if s.Images != nil && s.Images.Caption != nil {
+			captionData := struct {
+				Post  *core.PostBlock
+				Image *core.ImageBlock
+			}{
+				Post:  post,
+				Image: &post.ImageBlocks[0],
+			}
+			if s.Images.Caption.SystemTemplate != "" {
+				if err := typeCheckTextTemplate(fmt.Sprintf("post_summary[%d].images.caption.system_template", i), s.Images.Caption.SystemTemplate, captionData); err != nil {
+					return fmt.Errorf("post_summary %d (%s): images.caption.system_template type check failed: %w", i, s.Name, err)
+				}
+			}
+			if s.Images.Caption.PromptTemplate != "" {
+				if err := typeCheckTextTemplate(fmt.Sprintf("post_summary[%d].images.caption.prompt_template", i), s.Images.Caption.PromptTemplate, captionData); err != nil {
+					return fmt.Errorf("post_summary %d (%s): images.caption.prompt_template type check failed: %w", i, s.Name, err)
+				}
+			}
+		}
 	}
 
 	// Run summary LLM templates.
@@ -88,6 +126,25 @@ func (d *CuratorDocument) validateTemplateTypes() error {
 		if s.PromptTemplate != "" {
 			if err := typeCheckTextTemplate(fmt.Sprintf("run_summary[%d].prompt_template", i), s.PromptTemplate, data); err != nil {
 				return fmt.Errorf("run_summary %d (%s): prompt_template type check failed: %w", i, s.Name, err)
+			}
+		}
+		if s.Images != nil && s.Images.Caption != nil {
+			captionData := struct {
+				Post  *core.PostBlock
+				Image *core.ImageBlock
+			}{
+				Post:  post,
+				Image: &post.ImageBlocks[0],
+			}
+			if s.Images.Caption.SystemTemplate != "" {
+				if err := typeCheckTextTemplate(fmt.Sprintf("run_summary[%d].images.caption.system_template", i), s.Images.Caption.SystemTemplate, captionData); err != nil {
+					return fmt.Errorf("run_summary %d (%s): images.caption.system_template type check failed: %w", i, s.Name, err)
+				}
+			}
+			if s.Images.Caption.PromptTemplate != "" {
+				if err := typeCheckTextTemplate(fmt.Sprintf("run_summary[%d].images.caption.prompt_template", i), s.Images.Caption.PromptTemplate, captionData); err != nil {
+					return fmt.Errorf("run_summary %d (%s): images.caption.prompt_template type check failed: %w", i, s.Name, err)
+				}
 			}
 		}
 	}
@@ -180,4 +237,3 @@ func sampleRunSummaryForTemplateValidation() *core.RunSummary {
 		ProcessedAt:   now,
 	}
 }
-

--- a/internal/llm/llm.go
+++ b/internal/llm/llm.go
@@ -9,9 +9,23 @@ const (
 	RoleUser   MessageRole = "user"
 )
 
+type MessagePartType string
+
+const (
+	MessagePartText     MessagePartType = "text"
+	MessagePartImageURL MessagePartType = "image_url"
+)
+
+type MessagePart struct {
+	Type     MessagePartType
+	Text     string
+	ImageURL string
+}
+
 type Message struct {
 	Role    MessageRole
 	Content string
+	Parts   []MessagePart
 }
 
 type ChatRequest struct {

--- a/internal/llm/llm.go
+++ b/internal/llm/llm.go
@@ -25,7 +25,10 @@ type MessagePart struct {
 type Message struct {
 	Role    MessageRole
 	Content string
-	Parts   []MessagePart
+
+	// Multi-part message content is only valid for user messages and
+	// takes priority over Content in that case.
+	Parts []MessagePart
 }
 
 type ChatRequest struct {

--- a/internal/llm/openai/client.go
+++ b/internal/llm/openai/client.go
@@ -62,6 +62,7 @@ func (c *Client) ChatCompletion(ctx context.Context, request llm.ChatRequest) (l
 				span.SetStatus(codes.Error, err.Error())
 				return llm.ChatResponse{}, err
 			}
+
 			contentParts, err := openAIContentParts(msg.Parts)
 			if err != nil {
 				span.RecordError(err)

--- a/internal/llm/openai/client.go
+++ b/internal/llm/openai/client.go
@@ -68,6 +68,12 @@ func (c *Client) ChatCompletion(ctx context.Context, request llm.ChatRequest) (l
 				span.SetStatus(codes.Error, err.Error())
 				return llm.ChatResponse{}, err
 			}
+			if len(contentParts) == 0 {
+				err := fmt.Errorf("openai: message has no valid content parts")
+				span.RecordError(err)
+				span.SetStatus(codes.Error, err.Error())
+				return llm.ChatResponse{}, err
+			}
 			messages = append(messages, openai.UserMessage(contentParts))
 			continue
 		}

--- a/internal/processors/llmutil/images.go
+++ b/internal/processors/llmutil/images.go
@@ -1,0 +1,186 @@
+package llmutil
+
+import (
+	"context"
+	"encoding/base64"
+	"fmt"
+	"log/slog"
+	"sync"
+	"text/template"
+
+	"github.com/bakkerme/curator-ai/internal/config"
+	"github.com/bakkerme/curator-ai/internal/core"
+	"github.com/bakkerme/curator-ai/internal/llm"
+)
+
+type CaptionTemplates struct {
+	System *template.Template
+	Prompt *template.Template
+}
+
+type captionPromptData struct {
+	Post  *core.PostBlock
+	Image *core.ImageBlock
+}
+
+func CollectImageBlocks(block *core.PostBlock, includeCommentImages bool, maxImages int) []*core.ImageBlock {
+	if block == nil {
+		return nil
+	}
+	images := make([]*core.ImageBlock, 0, len(block.ImageBlocks))
+	for i := range block.ImageBlocks {
+		images = append(images, &block.ImageBlocks[i])
+	}
+	if includeCommentImages {
+		for ci := range block.Comments {
+			for ii := range block.Comments[ci].Images {
+				images = append(images, &block.Comments[ci].Images[ii])
+			}
+		}
+	}
+	if maxImages > 0 && len(images) > maxImages {
+		return images[:maxImages]
+	}
+	return images
+}
+
+func BuildUserMessageWithImages(userPrompt string, images []*core.ImageBlock) llm.Message {
+	parts := make([]llm.MessagePart, 0, len(images)+1)
+	if userPrompt != "" {
+		parts = append(parts, llm.MessagePart{Type: llm.MessagePartText, Text: userPrompt})
+	}
+	for _, image := range images {
+		if image == nil {
+			continue
+		}
+		if url, ok := imageURLForMessage(image); ok {
+			parts = append(parts, llm.MessagePart{Type: llm.MessagePartImageURL, ImageURL: url})
+		}
+	}
+	if len(parts) == 0 {
+		return llm.Message{Role: llm.RoleUser, Content: userPrompt}
+	}
+	return llm.Message{Role: llm.RoleUser, Parts: parts}
+}
+
+func EnsureImageCaptions(
+	ctx context.Context,
+	client llm.Client,
+	block *core.PostBlock,
+	imagesConfig *config.LLMImages,
+	templates CaptionTemplates,
+	defaultModel string,
+	defaultTemp *float64,
+	logger *slog.Logger,
+) error {
+	if imagesConfig == nil || !imagesConfig.Enabled || imagesConfig.Mode != config.ImageModeCaption {
+		return nil
+	}
+	if imagesConfig.Caption == nil {
+		return fmt.Errorf("image caption config is required when images.mode=caption")
+	}
+	if templates.System == nil || templates.Prompt == nil {
+		return fmt.Errorf("image caption templates are required when images.mode=caption")
+	}
+
+	images := CollectImageBlocks(block, imagesConfig.IncludeCommentImages, imagesConfig.MaxImages)
+	if len(images) == 0 {
+		return nil
+	}
+
+	model := ModelOrDefault(imagesConfig.Caption.Model, defaultModel)
+	temperature := imagesConfig.Caption.Temperature
+	if temperature == nil {
+		temperature = defaultTemp
+	}
+
+	captionOne := func(ctx context.Context, image *core.ImageBlock) error {
+		if image == nil || image.WasSummarised {
+			return nil
+		}
+		data := captionPromptData{
+			Post:  block,
+			Image: image,
+		}
+		systemPrompt, err := ExecuteTemplate(templates.System, data)
+		if err != nil {
+			return err
+		}
+		userPrompt, err := ExecuteTemplate(templates.Prompt, data)
+		if err != nil {
+			return err
+		}
+
+		if logger != nil {
+			logger.Info("llm image captioning", "image_url", image.URL, "model", model)
+		}
+		resp, err := ChatSystemUserWithRetries(ctx, client, model, systemPrompt, userPrompt, 3, nil, temperature)
+		if err != nil {
+			return err
+		}
+		image.Summary = resp.Content
+		image.WasSummarised = true
+		return nil
+	}
+
+	maxConcurrency := imagesConfig.Caption.MaxConcurrency
+	if maxConcurrency <= 1 || len(images) <= 1 {
+		for _, image := range images {
+			if err := captionOne(ctx, image); err != nil {
+				return err
+			}
+		}
+		return nil
+	}
+
+	ctx, cancel := context.WithCancel(ctx)
+	defer cancel()
+
+	sem := make(chan struct{}, maxConcurrency)
+	var wg sync.WaitGroup
+	errCh := make(chan error, 1)
+
+	for _, image := range images {
+		image := image
+		select {
+		case sem <- struct{}{}:
+		case <-ctx.Done():
+			break
+		}
+
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			defer func() { <-sem }()
+			if err := captionOne(ctx, image); err != nil {
+				select {
+				case errCh <- err:
+				default:
+				}
+				cancel()
+			}
+		}()
+	}
+
+	wg.Wait()
+	select {
+	case err := <-errCh:
+		return err
+	default:
+		return nil
+	}
+}
+
+func imageURLForMessage(image *core.ImageBlock) (string, bool) {
+	if image == nil {
+		return "", false
+	}
+	if image.URL != "" {
+		return image.URL, true
+	}
+	if len(image.ImageData) == 0 {
+		return "", false
+	}
+	encoded := base64.StdEncoding.EncodeToString(image.ImageData)
+	return fmt.Sprintf("data:image/png;base64,%s", encoded), true
+}

--- a/internal/processors/llmutil/images_test.go
+++ b/internal/processors/llmutil/images_test.go
@@ -1,0 +1,57 @@
+package llmutil
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/bakkerme/curator-ai/internal/core"
+)
+
+func TestImageURLForMessage_DataURL_UsesDetectedMimeType(t *testing.T) {
+	t.Run("png", func(t *testing.T) {
+		img := &core.ImageBlock{ImageData: []byte{
+			0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A, // PNG signature
+			0x00, 0x00, 0x00, 0x0D, // some extra bytes
+		}}
+		url, ok := imageURLForMessage(img)
+		if !ok {
+			t.Fatalf("expected ok=true")
+		}
+		if !strings.HasPrefix(url, "data:image/png;base64,") {
+			t.Fatalf("expected png data url prefix, got %q", url)
+		}
+	})
+
+	t.Run("jpeg", func(t *testing.T) {
+		img := &core.ImageBlock{ImageData: []byte{
+			0xFF, 0xD8, 0xFF, 0xE0, // JPEG SOI + JFIF marker-ish
+			0x00, 0x10, 0x4A, 0x46, 0x49, 0x46, 0x00, // "JFIF\x00"
+		}}
+		url, ok := imageURLForMessage(img)
+		if !ok {
+			t.Fatalf("expected ok=true")
+		}
+		if !strings.HasPrefix(url, "data:image/jpeg;base64,") {
+			t.Fatalf("expected jpeg data url prefix, got %q", url)
+		}
+	})
+}
+
+func TestImageURLForMessage_ReturnsFalseForUnknownBytes(t *testing.T) {
+	img := &core.ImageBlock{ImageData: []byte("not-an-image")}
+	_, ok := imageURLForMessage(img)
+	if ok {
+		t.Fatalf("expected ok=false")
+	}
+}
+
+func TestImageURLForMessage_UsesURLWhenPresent(t *testing.T) {
+	img := &core.ImageBlock{URL: "https://example.com/a.jpg", ImageData: []byte("not-an-image")}
+	url, ok := imageURLForMessage(img)
+	if !ok {
+		t.Fatalf("expected ok=true")
+	}
+	if url != img.URL {
+		t.Fatalf("expected %q, got %q", img.URL, url)
+	}
+}

--- a/internal/processors/llmutil/images_test.go
+++ b/internal/processors/llmutil/images_test.go
@@ -124,7 +124,7 @@ func TestEnsureImageCaptions_GuardsAndBasicBehavior(t *testing.T) {
 
 	t.Run("disabled does nothing", func(t *testing.T) {
 		cfg := &config.LLMImages{Enabled: false, Mode: config.ImageModeCaption, Caption: &config.LLMImageCaption{}}
-		err := EnsureImageCaptions(ctx, client, block, cfg, CaptionTemplates{}, "m", nil, nil, nil)
+		err := EnsureImageCaptions(ctx, client, block, cfg, CaptionTemplates{}, "m", nil, nil)
 		if err != nil {
 			t.Fatalf("expected nil, got %v", err)
 		}
@@ -132,7 +132,7 @@ func TestEnsureImageCaptions_GuardsAndBasicBehavior(t *testing.T) {
 
 	t.Run("missing caption config errors", func(t *testing.T) {
 		cfg := &config.LLMImages{Enabled: true, Mode: config.ImageModeCaption}
-		err := EnsureImageCaptions(ctx, client, block, cfg, CaptionTemplates{System: template.Must(template.New("s").Parse("s")), Prompt: template.Must(template.New("p").Parse("p"))}, "m", nil, nil, nil)
+		err := EnsureImageCaptions(ctx, client, block, cfg, CaptionTemplates{System: template.Must(template.New("s").Parse("s")), Prompt: template.Must(template.New("p").Parse("p"))}, "m", nil, nil)
 		if err == nil {
 			t.Fatalf("expected error")
 		}
@@ -140,7 +140,7 @@ func TestEnsureImageCaptions_GuardsAndBasicBehavior(t *testing.T) {
 
 	t.Run("missing templates errors", func(t *testing.T) {
 		cfg := &config.LLMImages{Enabled: true, Mode: config.ImageModeCaption, Caption: &config.LLMImageCaption{}}
-		err := EnsureImageCaptions(ctx, client, block, cfg, CaptionTemplates{}, "m", nil, nil, nil)
+		err := EnsureImageCaptions(ctx, client, block, cfg, CaptionTemplates{}, "m", nil, nil)
 		if err == nil {
 			t.Fatalf("expected error")
 		}
@@ -152,7 +152,7 @@ func TestEnsureImageCaptions_GuardsAndBasicBehavior(t *testing.T) {
 			System: template.Must(template.New("s").Parse("system")),
 			Prompt: template.Must(template.New("p").Parse("prompt")),
 		}
-		err := EnsureImageCaptions(ctx, client, &core.PostBlock{}, cfg, tmpls, "m", nil, nil, nil)
+		err := EnsureImageCaptions(ctx, client, &core.PostBlock{}, cfg, tmpls, "m", nil, nil)
 		if err != nil {
 			t.Fatalf("expected nil, got %v", err)
 		}
@@ -186,7 +186,7 @@ func TestEnsureImageCaptions_CaptionsAndRespectsIncludeAndMaxImages(t *testing.T
 		Prompt: template.Must(template.New("p").Parse("{{.Image.URL}}")),
 	}
 
-	err := EnsureImageCaptions(ctx, client, block, cfg, tmpls, "m", nil, nil, nil)
+	err := EnsureImageCaptions(ctx, client, block, cfg, tmpls, "m", nil, nil)
 	if err != nil {
 		t.Fatalf("expected nil, got %v", err)
 	}
@@ -267,7 +267,7 @@ func TestEnsureImageCaptions_ConcurrentCaptioningRespectsMaxConcurrency(t *testi
 		close(unblock)
 	}()
 
-	err := EnsureImageCaptions(ctx, client, block, cfg, tmpls, "m", nil, nil, nil)
+	err := EnsureImageCaptions(ctx, client, block, cfg, tmpls, "m", nil, nil)
 	if err != nil {
 		t.Fatalf("expected nil, got %v", err)
 	}

--- a/internal/processors/llmutil/images_test.go
+++ b/internal/processors/llmutil/images_test.go
@@ -1,11 +1,289 @@
 package llmutil
 
 import (
+	"context"
 	"strings"
+	"sync/atomic"
 	"testing"
+	"text/template"
+	"time"
 
+	"github.com/bakkerme/curator-ai/internal/config"
 	"github.com/bakkerme/curator-ai/internal/core"
+	"github.com/bakkerme/curator-ai/internal/llm"
 )
+
+type mockLLMClient struct {
+	chatCompletion func(ctx context.Context, request llm.ChatRequest) (llm.ChatResponse, error)
+}
+
+func (m *mockLLMClient) ChatCompletion(ctx context.Context, request llm.ChatRequest) (llm.ChatResponse, error) {
+	if m.chatCompletion == nil {
+		return llm.ChatResponse{Content: "ok"}, nil
+	}
+	return m.chatCompletion(ctx, request)
+}
+
+func TestCollectImageBlocks_NilBlock(t *testing.T) {
+	imgs := CollectImageBlocks(nil, true, 10)
+	if imgs != nil {
+		t.Fatalf("expected nil, got %v", imgs)
+	}
+}
+
+func TestCollectImageBlocks_CollectsPostAndCommentImagesAndRespectsMax(t *testing.T) {
+	block := &core.PostBlock{
+		ImageBlocks: []core.ImageBlock{{URL: "post-1"}, {URL: "post-2"}},
+		Comments: []core.CommentBlock{
+			{Images: []core.ImageBlock{{URL: "c1-1"}, {URL: "c1-2"}}},
+			{Images: []core.ImageBlock{{URL: "c2-1"}}},
+		},
+	}
+
+	t.Run("exclude comment images", func(t *testing.T) {
+		imgs := CollectImageBlocks(block, false, 0)
+		if len(imgs) != 2 {
+			t.Fatalf("expected 2 images, got %d", len(imgs))
+		}
+		if imgs[0].URL != "post-1" || imgs[1].URL != "post-2" {
+			t.Fatalf("unexpected urls: %q, %q", imgs[0].URL, imgs[1].URL)
+		}
+	})
+
+	t.Run("include comment images", func(t *testing.T) {
+		imgs := CollectImageBlocks(block, true, 0)
+		if len(imgs) != 5 {
+			t.Fatalf("expected 5 images, got %d", len(imgs))
+		}
+		got := []string{imgs[0].URL, imgs[1].URL, imgs[2].URL, imgs[3].URL, imgs[4].URL}
+		want := []string{"post-1", "post-2", "c1-1", "c1-2", "c2-1"}
+		for i := range want {
+			if got[i] != want[i] {
+				t.Fatalf("unexpected order at %d: got %q want %q", i, got[i], want[i])
+			}
+		}
+	})
+
+	t.Run("max images truncates", func(t *testing.T) {
+		imgs := CollectImageBlocks(block, true, 3)
+		if len(imgs) != 3 {
+			t.Fatalf("expected 3 images, got %d", len(imgs))
+		}
+		got := []string{imgs[0].URL, imgs[1].URL, imgs[2].URL}
+		want := []string{"post-1", "post-2", "c1-1"}
+		for i := range want {
+			if got[i] != want[i] {
+				t.Fatalf("unexpected order at %d: got %q want %q", i, got[i], want[i])
+			}
+		}
+	})
+}
+
+func TestBuildUserMessageWithImages(t *testing.T) {
+	t.Run("nil and empty inputs", func(t *testing.T) {
+		msg := BuildUserMessageWithImages("", nil)
+		if msg.Role != llm.RoleUser {
+			t.Fatalf("expected role user, got %q", msg.Role)
+		}
+		if msg.Content != "" {
+			t.Fatalf("expected empty content, got %q", msg.Content)
+		}
+		if len(msg.Parts) != 0 {
+			t.Fatalf("expected no parts, got %d", len(msg.Parts))
+		}
+	})
+
+	t.Run("text then image parts, skips nil images", func(t *testing.T) {
+		images := []*core.ImageBlock{nil, {URL: "https://example.com/a.png"}, {URL: "https://example.com/b.png"}}
+		msg := BuildUserMessageWithImages("hello", images)
+		if msg.Role != llm.RoleUser {
+			t.Fatalf("expected role user, got %q", msg.Role)
+		}
+		if msg.Content != "" {
+			t.Fatalf("expected empty content when parts present, got %q", msg.Content)
+		}
+		if len(msg.Parts) != 3 {
+			t.Fatalf("expected 3 parts, got %d", len(msg.Parts))
+		}
+		if msg.Parts[0].Type != llm.MessagePartText || msg.Parts[0].Text != "hello" {
+			t.Fatalf("unexpected first part: %#v", msg.Parts[0])
+		}
+		if msg.Parts[1].Type != llm.MessagePartImageURL || msg.Parts[1].ImageURL != "https://example.com/a.png" {
+			t.Fatalf("unexpected second part: %#v", msg.Parts[1])
+		}
+		if msg.Parts[2].Type != llm.MessagePartImageURL || msg.Parts[2].ImageURL != "https://example.com/b.png" {
+			t.Fatalf("unexpected third part: %#v", msg.Parts[2])
+		}
+	})
+}
+
+func TestEnsureImageCaptions_GuardsAndBasicBehavior(t *testing.T) {
+	ctx := context.Background()
+	client := &mockLLMClient{}
+	block := &core.PostBlock{}
+
+	t.Run("disabled does nothing", func(t *testing.T) {
+		cfg := &config.LLMImages{Enabled: false, Mode: config.ImageModeCaption, Caption: &config.LLMImageCaption{}}
+		err := EnsureImageCaptions(ctx, client, block, cfg, CaptionTemplates{}, "m", nil, nil, nil)
+		if err != nil {
+			t.Fatalf("expected nil, got %v", err)
+		}
+	})
+
+	t.Run("missing caption config errors", func(t *testing.T) {
+		cfg := &config.LLMImages{Enabled: true, Mode: config.ImageModeCaption}
+		err := EnsureImageCaptions(ctx, client, block, cfg, CaptionTemplates{System: template.Must(template.New("s").Parse("s")), Prompt: template.Must(template.New("p").Parse("p"))}, "m", nil, nil, nil)
+		if err == nil {
+			t.Fatalf("expected error")
+		}
+	})
+
+	t.Run("missing templates errors", func(t *testing.T) {
+		cfg := &config.LLMImages{Enabled: true, Mode: config.ImageModeCaption, Caption: &config.LLMImageCaption{}}
+		err := EnsureImageCaptions(ctx, client, block, cfg, CaptionTemplates{}, "m", nil, nil, nil)
+		if err == nil {
+			t.Fatalf("expected error")
+		}
+	})
+
+	t.Run("no images no-ops", func(t *testing.T) {
+		cfg := &config.LLMImages{Enabled: true, Mode: config.ImageModeCaption, Caption: &config.LLMImageCaption{MaxConcurrency: 2}}
+		tmpls := CaptionTemplates{
+			System: template.Must(template.New("s").Parse("system")),
+			Prompt: template.Must(template.New("p").Parse("prompt")),
+		}
+		err := EnsureImageCaptions(ctx, client, &core.PostBlock{}, cfg, tmpls, "m", nil, nil, nil)
+		if err != nil {
+			t.Fatalf("expected nil, got %v", err)
+		}
+	})
+}
+
+func TestEnsureImageCaptions_CaptionsAndRespectsIncludeAndMaxImages(t *testing.T) {
+	ctx := context.Background()
+
+	var calls atomic.Int32
+	client := &mockLLMClient{chatCompletion: func(ctx context.Context, request llm.ChatRequest) (llm.ChatResponse, error) {
+		calls.Add(1)
+		return llm.ChatResponse{Content: "caption:" + request.Messages[1].Content}, nil
+	}}
+
+	block := &core.PostBlock{
+		ImageBlocks: []core.ImageBlock{{URL: "post-1"}},
+		Comments:    []core.CommentBlock{{Images: []core.ImageBlock{{URL: "c1-1"}, {URL: "c1-2"}}}},
+	}
+
+	cfg := &config.LLMImages{
+		Enabled:              true,
+		Mode:                 config.ImageModeCaption,
+		IncludeCommentImages: true,
+		MaxImages:            2,
+		Caption:              &config.LLMImageCaption{MaxConcurrency: 1},
+	}
+
+	tmpls := CaptionTemplates{
+		System: template.Must(template.New("s").Parse("sys")),
+		Prompt: template.Must(template.New("p").Parse("{{.Image.URL}}")),
+	}
+
+	err := EnsureImageCaptions(ctx, client, block, cfg, tmpls, "m", nil, nil, nil)
+	if err != nil {
+		t.Fatalf("expected nil, got %v", err)
+	}
+
+	if calls.Load() != 2 {
+		t.Fatalf("expected 2 caption calls, got %d", calls.Load())
+	}
+	if !block.ImageBlocks[0].WasSummarised || block.ImageBlocks[0].Summary == "" {
+		t.Fatalf("expected post image to be summarised")
+	}
+	if !block.Comments[0].Images[0].WasSummarised || block.Comments[0].Images[0].Summary == "" {
+		t.Fatalf("expected first comment image to be summarised")
+	}
+	if block.Comments[0].Images[1].WasSummarised {
+		t.Fatalf("expected second comment image to be skipped due to max_images")
+	}
+}
+
+func TestEnsureImageCaptions_ConcurrentCaptioningRespectsMaxConcurrency(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+
+	var inFlight atomic.Int32
+	var maxInFlight atomic.Int32
+	startedCh := make(chan struct{}, 10)
+	unblock := make(chan struct{})
+
+	client := &mockLLMClient{chatCompletion: func(ctx context.Context, request llm.ChatRequest) (llm.ChatResponse, error) {
+		cur := inFlight.Add(1)
+		for {
+			prev := maxInFlight.Load()
+			if cur <= prev {
+				break
+			}
+			if maxInFlight.CompareAndSwap(prev, cur) {
+				break
+			}
+		}
+		select {
+		case startedCh <- struct{}{}:
+		default:
+		}
+		select {
+		case <-unblock:
+		case <-ctx.Done():
+			inFlight.Add(-1)
+			return llm.ChatResponse{}, ctx.Err()
+		}
+		inFlight.Add(-1)
+		return llm.ChatResponse{Content: "ok"}, nil
+	}}
+
+	block := &core.PostBlock{
+		ImageBlocks: []core.ImageBlock{{URL: "a"}, {URL: "b"}, {URL: "c"}},
+	}
+	maxConc := 2
+	cfg := &config.LLMImages{
+		Enabled: true,
+		Mode:    config.ImageModeCaption,
+		Caption: &config.LLMImageCaption{MaxConcurrency: maxConc},
+	}
+	tmpls := CaptionTemplates{
+		System: template.Must(template.New("s").Parse("sys")),
+		Prompt: template.Must(template.New("p").Parse("{{.Image.URL}}")),
+	}
+
+	// Release once we observe at least 2 concurrent starts.
+	go func() {
+		seen := 0
+		for seen < maxConc {
+			select {
+			case <-startedCh:
+				seen++
+			case <-ctx.Done():
+				return
+			}
+		}
+		close(unblock)
+	}()
+
+	err := EnsureImageCaptions(ctx, client, block, cfg, tmpls, "m", nil, nil, nil)
+	if err != nil {
+		t.Fatalf("expected nil, got %v", err)
+	}
+
+	if maxInFlight.Load() < 2 {
+		t.Fatalf("expected some concurrency (maxInFlight>=2), got %d", maxInFlight.Load())
+	}
+	if maxInFlight.Load() > int32(maxConc) {
+		t.Fatalf("expected max concurrency <= %d, got %d", maxConc, maxInFlight.Load())
+	}
+	for i := range block.ImageBlocks {
+		if !block.ImageBlocks[i].WasSummarised {
+			t.Fatalf("expected image %d to be summarised", i)
+		}
+	}
+}
 
 func TestImageURLForMessage_DataURL_UsesDetectedMimeType(t *testing.T) {
 	t.Run("png", func(t *testing.T) {

--- a/planning/curator_document_spec.md
+++ b/planning/curator_document_spec.md
@@ -98,6 +98,17 @@ llm:
   exclusions: [string]           # Negative criteria - content matching these is dropped
   action_type: string            # "pass_drop" - binary decision
   threshold: number              # Optional: Score threshold (0-1) for pass/drop decision
+  images:
+    enabled: boolean             # Optional: attach images for LLM stages
+    mode: string                 # "multimodal" | "caption"
+    max_images: number           # Optional: cap images per post (0 = unlimited)
+    include_comment_images: bool # Optional: include images from comments
+    caption:                     # Required when mode is "caption"
+      model: string              # Optional: Model override for captioning
+      system_template: string    # Reference to caption system template
+      prompt_template: string    # Reference to caption prompt template
+      temperature: number        # Optional: sampling temperature for captions
+      max_concurrency: number    # Optional: concurrency for caption calls
 ```
 
 ### Summary Processors
@@ -115,6 +126,17 @@ llm:
   prompt_template: string        # Reference to prompt template
   params:                        # Optional: Additional parameters for the prompt
     my_additional_param: [string]          # An additional example param
+  images:
+    enabled: boolean             # Optional: attach images for LLM stages
+    mode: string                 # "multimodal" | "caption"
+    max_images: number           # Optional: cap images per post (0 = unlimited)
+    include_comment_images: bool # Optional: include images from comments
+    caption:                     # Required when mode is "caption"
+      model: string              # Optional: Model override for captioning
+      system_template: string    # Reference to caption system template
+      prompt_template: string    # Reference to caption prompt template
+      temperature: number        # Optional: sampling temperature for captions
+      max_concurrency: number    # Optional: concurrency for caption calls
 ```
 
 #### Markdown Summary (Post-level)

--- a/planning/curator_document_spec.md
+++ b/planning/curator_document_spec.md
@@ -105,8 +105,7 @@ llm:
     include_comment_images: bool # Optional: include images from comments
     caption:                     # Required when mode is "caption"
       model: string              # Optional: Model override for captioning
-      system_template: string    # Reference to caption system template
-      prompt_template: string    # Reference to caption prompt template
+      template: string           # Reference to caption templates
       temperature: number        # Optional: sampling temperature for captions
       max_concurrency: number    # Optional: concurrency for caption calls
 ```
@@ -133,8 +132,7 @@ llm:
     include_comment_images: bool # Optional: include images from comments
     caption:                     # Required when mode is "caption"
       model: string              # Optional: Model override for captioning
-      system_template: string    # Reference to caption system template
-      prompt_template: string    # Reference to caption prompt template
+      template: string           # Reference to caption templates
       temperature: number        # Optional: sampling temperature for captions
       max_concurrency: number    # Optional: concurrency for caption calls
 ```


### PR DESCRIPTION
### Motivation

- Enable LLM-based processors to consume and reason over images either by automatically captioning images or by sending multimodal inputs to the LLM provider. 
- Provide configuration for image handling in LLM quality and summary processors so workflows can opt into captioning or multimodal modes. 
- Ensure templates used for image captioning are validated and can be referenced from `templates` blocks like other prompt templates. 
- Integrate image handling into existing LLM utilities and the OpenAI client to keep message construction and retries consistent.

### Description

- Extended the config schema with `LLMImages`, added `images` fields to `LLMQuality` and `LLMSummary`, and added validation and template resolution for image caption templates in `internal/config/schema.go` and `internal/config/template_typecheck.go`.
- Added multipart message support to the LLM layer with `MessagePart` and `Parts` in `internal/llm/llm.go` and implemented conversion to OpenAI content parts in `internal/llm/openai/client.go` via `openAIContentParts`.
- Implemented image helpers in `internal/processors/llmutil/images.go` that collect images, optionally caption images via `EnsureImageCaptions`, build user messages containing text + image parts, and encode image data as data-URIs when needed.
- Updated LLM processors (`internal/processors/quality/llm.go` and `internal/processors/summary/llm.go`) to perform captioning when configured and to send multimodal messages when `images.mode=multimodal`, and added example workflow docs (`curator-docs/*`) and spec docs updates (`planning/curator_document_spec.md`).

### Testing

- Ran `gofmt` across modified files to ensure formatting was applied successfully.
- Ran the full test suite with `go test ./...` and the unit tests completed successfully with no failing packages.
- Added validation unit tests for the new image configuration scenarios in `internal/config/schema_test.go` and they passed as part of the test run.
- Verified package builds and processor tests (`internal/processors/quality`, `internal/processors/summary`, `internal/config`, `internal/outputs/email/smtp`, and `internal/runner`) completed successfully during the `go test ./...` run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695f3153cef0832cb5ad031848b12ee4)