### PR TITLE
Remove use_tls in favor of smtp_tls_mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ go run ./cmd/curator -config curator.yaml -run-once
 - `SMTP_PORT` (optional, default: `587`)
 - `SMTP_USER` (optional, depends on provider)
 - `SMTP_PASSWORD` (optional, depends on provider)
-- `SMTP_TLS_MODE` (optional, `auto`, `starttls`, `implicit`, `disabled`)
+- `SMTP_TLS_MODE` (optional, default: `auto`; values: `auto`, `starttls`, `implicit`, `disabled`)
 
 ### HTTP Source Settings
 - `REDDIT_HTTP_TIMEOUT` (optional, e.g. `10s`)

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ go run ./cmd/curator -config curator.yaml -run-once
 - `SMTP_PORT` (optional, default: `587`)
 - `SMTP_USER` (optional, depends on provider)
 - `SMTP_PASSWORD` (optional, depends on provider)
-- `SMTP_USE_TLS` (optional, default: `true`)
+- `SMTP_TLS_MODE` (optional, `auto`, `starttls`, `implicit`, `disabled`)
 
 ### HTTP Source Settings
 - `REDDIT_HTTP_TIMEOUT` (optional, e.g. `10s`)

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -24,7 +24,7 @@ services:
       CURATOR_CONFIG: /app/curator.yaml
       SMTP_HOST: mailpit
       SMTP_PORT: 1025
-      SMTP_USE_TLS: "false"
+      SMTP_TLS_MODE: "disabled"
       SMTP_USER: "dummy@dummy"
       SMTP_PASSWORD: "dummy"
 

--- a/docs/curator_document_spec.md
+++ b/docs/curator_document_spec.md
@@ -204,7 +204,7 @@ email:
   smtp_port: number              # Optional: SMTP port (default: from config)
   smtp_user: string              # Optional: SMTP username (default: from config)
   smtp_password: string          # Optional: SMTP password (default: from config)
-  use_tls: boolean               # Optional: Enable TLS (default: true)
+  smtp_tls_mode: string          # Optional: "auto" (default), "starttls", "implicit", "disabled"
 ```
 
 ## Data Flow and Processing Order

--- a/internal/config/env.go
+++ b/internal/config/env.go
@@ -72,7 +72,7 @@ type SMTPEnvConfig struct {
 	Port     int
 	User     string
 	Password string
-	UseTLS   bool
+	TLSMode  string
 }
 
 func LoadEnv() EnvConfig {
@@ -135,7 +135,7 @@ func LoadEnv() EnvConfig {
 			Port:     envInt("SMTP_PORT", 587),
 			User:     envString("SMTP_USER", ""),
 			Password: envString("SMTP_PASSWORD", ""),
-			UseTLS:   envBool("SMTP_USE_TLS", true),
+			TLSMode:  envString("SMTP_TLS_MODE", ""),
 		},
 	}
 }

--- a/internal/config/schema.go
+++ b/internal/config/schema.go
@@ -235,7 +235,7 @@ type EmailOutput struct {
 	SMTPPort     int                  `yaml:"smtp_port,omitempty"`
 	SMTPUser     string               `yaml:"smtp_user,omitempty"`
 	SMTPPassword string               `yaml:"smtp_password,omitempty"`
-	UseTLS       *bool                `yaml:"use_tls,omitempty"`
+	SMTPTLSMode  string               `yaml:"smtp_tls_mode,omitempty"`
 	Snapshot     *core.SnapshotConfig `yaml:"snapshot,omitempty"`
 }
 

--- a/internal/config/schema_test.go
+++ b/internal/config/schema_test.go
@@ -10,10 +10,6 @@ import (
 	"gopkg.in/yaml.v3"
 )
 
-func boolPtr(value bool) *bool {
-	return &value
-}
-
 func TestParseExampleFlow(t *testing.T) {
 	data := []byte(`
 workflow:
@@ -793,7 +789,7 @@ func TestParseEmailOutputConfig(t *testing.T) {
 				SMTPPort:     2525,
 				SMTPUser:     "user",
 				SMTPPassword: "pass",
-				UseTLS:       boolPtr(true),
+				SMTPTLSMode:  "starttls",
 			}}},
 		},
 	}
@@ -822,8 +818,8 @@ func TestParseEmailOutputConfig(t *testing.T) {
 	if emailConfig.SMTPPassword != "pass" {
 		t.Errorf("Expected smtp password, got %s", emailConfig.SMTPPassword)
 	}
-	if emailConfig.UseTLS == nil || !*emailConfig.UseTLS {
-		t.Errorf("Expected use_tls true")
+	if emailConfig.SMTPTLSMode != "starttls" {
+		t.Errorf("Expected smtp_tls_mode starttls, got %q", emailConfig.SMTPTLSMode)
 	}
 }
 

--- a/internal/e2e/mailpit_test.go
+++ b/internal/e2e/mailpit_test.go
@@ -76,7 +76,7 @@ func TestMailpitE2E(t *testing.T) {
 		"SMTP_PORT=1025",
 		"SMTP_USER=user@curator.ai",
 		"SMTP_PASSWORD=123asdf123",
-		"SMTP_USE_TLS=false",
+		"SMTP_TLS_MODE=disabled",
 	)
 
 	cmd := exec.CommandContext(ctx, "go", "run", "./cmd/curator", "-config", flowFile, "-run-once")
@@ -138,7 +138,7 @@ const flowFixtureYAML = `workflow:
         subject: "Curator Mailpit E2E __RUN_ID__"
         smtp_host: "localhost"
         smtp_port: 1025
-        use_tls: false
+        smtp_tls_mode: "disabled"
         template: |-
           <html>
             <body>

--- a/internal/outputs/email/smtp/sender.go
+++ b/internal/outputs/email/smtp/sender.go
@@ -154,7 +154,7 @@ func parseTLSMode(mode string) (TLSMode, error) {
 	case "implicit", "smtptls", "smtp_tls":
 		return TLSModeImplicit, nil
 	default:
-		return "", fmt.Errorf("invalid smtp tls mode %q (expected auto, disabled, starttls, implicit)", mode)
+		return "", fmt.Errorf("invalid smtp tls mode %q (expected: auto, disabled/off/none, starttls/start_tls, implicit/smtptls/smtp_tls)", mode)
 	}
 }
 

--- a/internal/outputs/email/smtp/sender.go
+++ b/internal/outputs/email/smtp/sender.go
@@ -16,18 +16,34 @@ type Sender struct {
 	port     int
 	username string
 	password string
-	useTLS   bool
+	tlsMode  string
 }
 
-func NewSender(host string, port int, username, password string, useTLS bool) *Sender {
+// NewSender creates an SMTP sender with explicit TLS mode support.
+// The tlsMode value is optional; if empty, port-based defaults apply.
+func NewSender(host string, port int, username, password string, tlsMode string) *Sender {
 	return &Sender{
 		host:     host,
 		port:     port,
 		username: username,
 		password: password,
-		useTLS:   useTLS,
+		tlsMode:  tlsMode,
 	}
 }
+
+// TLSMode determines how the SMTP client should negotiate TLS.
+type TLSMode string
+
+const (
+	// TLSModeAuto uses port-based defaults (implicit TLS on 465, STARTTLS otherwise).
+	TLSModeAuto TLSMode = "auto"
+	// TLSModeDisabled forces cleartext SMTP.
+	TLSModeDisabled TLSMode = "disabled"
+	// TLSModeStartTLS requires STARTTLS on the SMTP connection.
+	TLSModeStartTLS TLSMode = "starttls"
+	// TLSModeImplicit uses implicit TLS (SMTPS), typically on port 465.
+	TLSModeImplicit TLSMode = "implicit"
+)
 
 func (s *Sender) Send(ctx context.Context, message email.Message) error {
 	if message.From == "" {
@@ -51,20 +67,25 @@ func (s *Sender) Send(ctx context.Context, message email.Message) error {
 	}
 
 	sendWithAuth := func(enableAuth bool) error {
+		mode, modeErr := s.resolveTLSMode()
+		if modeErr != nil {
+			return modeErr
+		}
+
 		clientOpts := []mail.Option{
 			mail.WithPort(s.port),
 			mail.WithTLSConfig(&tls.Config{ServerName: s.host, MinVersion: tls.VersionTLS12}),
 		}
-		if s.useTLS {
-			// Preserve prior behavior: when useTLS is true and port is 465, use implicit TLS.
-			// Otherwise, prefer STARTTLS.
-			if s.port == 465 {
-				clientOpts = append(clientOpts, mail.WithSSL())
-			} else {
-				clientOpts = append(clientOpts, mail.WithTLSPortPolicy(mail.TLSMandatory))
-			}
-		} else {
+
+		switch mode {
+		case TLSModeDisabled:
 			clientOpts = append(clientOpts, mail.WithTLSPortPolicy(mail.NoTLS))
+		case TLSModeStartTLS:
+			clientOpts = append(clientOpts, mail.WithTLSPortPolicy(mail.TLSMandatory))
+		case TLSModeImplicit:
+			clientOpts = append(clientOpts, mail.WithSSL())
+		default:
+			return fmt.Errorf("unsupported smtp tls mode %q", mode)
 		}
 
 		if enableAuth && s.username != "" {
@@ -102,6 +123,39 @@ func (s *Sender) Send(ctx context.Context, message email.Message) error {
 	}
 
 	return err
+}
+
+// resolveTLSMode returns the configured TLS behavior, falling back to port defaults.
+func (s *Sender) resolveTLSMode() (TLSMode, error) {
+	mode, err := parseTLSMode(s.tlsMode)
+	if err != nil {
+		return "", err
+	}
+	if mode == TLSModeAuto {
+		if s.port == 465 {
+			return TLSModeImplicit, nil
+		}
+		return TLSModeStartTLS, nil
+	}
+	return mode, nil
+}
+
+// parseTLSMode normalizes the TLS mode string and validates supported values.
+func parseTLSMode(mode string) (TLSMode, error) {
+	normalized := strings.TrimSpace(strings.ToLower(mode))
+	if normalized == "" || normalized == string(TLSModeAuto) {
+		return TLSModeAuto, nil
+	}
+	switch normalized {
+	case "disabled", "off", "none":
+		return TLSModeDisabled, nil
+	case "starttls", "start_tls":
+		return TLSModeStartTLS, nil
+	case "implicit", "smtptls", "smtp_tls":
+		return TLSModeImplicit, nil
+	default:
+		return "", fmt.Errorf("invalid smtp tls mode %q (expected auto, disabled, starttls, implicit)", mode)
+	}
 }
 
 func ValidateConfig(host string, port int) error {

--- a/internal/outputs/email/smtp/sender_test.go
+++ b/internal/outputs/email/smtp/sender_test.go
@@ -21,3 +21,66 @@ func TestIsLocalDevSMTPHost(t *testing.T) {
 	}
 }
 
+func TestParseTLSMode(t *testing.T) {
+	cases := []struct {
+		mode    string
+		want    TLSMode
+		wantErr bool
+	}{
+		{"", TLSModeAuto, false},
+		{"auto", TLSModeAuto, false},
+		{"disabled", TLSModeDisabled, false},
+		{"off", TLSModeDisabled, false},
+		{"starttls", TLSModeStartTLS, false},
+		{"start_tls", TLSModeStartTLS, false},
+		{"implicit", TLSModeImplicit, false},
+		{"smtptls", TLSModeImplicit, false},
+		{"smtp_tls", TLSModeImplicit, false},
+		{"unknown", "", true},
+	}
+
+	for _, tc := range cases {
+		got, err := parseTLSMode(tc.mode)
+		if tc.wantErr {
+			if err == nil {
+				t.Fatalf("parseTLSMode(%q) expected error", tc.mode)
+			}
+			continue
+		}
+		if err != nil {
+			t.Fatalf("parseTLSMode(%q) unexpected error: %v", tc.mode, err)
+		}
+		if got != tc.want {
+			t.Fatalf("parseTLSMode(%q)=%v want %v", tc.mode, got, tc.want)
+		}
+	}
+}
+
+func TestResolveTLSMode(t *testing.T) {
+	cases := []struct {
+		name string
+		port int
+		mode string
+		want TLSMode
+	}{
+		{"auto-implicit", 465, "", TLSModeImplicit},
+		{"auto-starttls", 587, "", TLSModeStartTLS},
+		{"explicit-starttls", 465, "starttls", TLSModeStartTLS},
+		{"explicit-implicit", 587, "implicit", TLSModeImplicit},
+		{"explicit-disabled", 25, "disabled", TLSModeDisabled},
+	}
+
+	for _, tc := range cases {
+		sender := &Sender{
+			port:    tc.port,
+			tlsMode: tc.mode,
+		}
+		got, err := sender.resolveTLSMode()
+		if err != nil {
+			t.Fatalf("resolveTLSMode(%s) unexpected error: %v", tc.name, err)
+		}
+		if got != tc.want {
+			t.Fatalf("resolveTLSMode(%s)=%v want %v", tc.name, got, tc.want)
+		}
+	}
+}

--- a/internal/runner/factory/factory.go
+++ b/internal/runner/factory/factory.go
@@ -131,11 +131,7 @@ func (f *Factory) NewEmailOutput(cfg *config.EmailOutput) (core.OutputProcessor,
 	merged := f.mergeEmailConfig(cfg)
 	sender := f.EmailSender
 	if sender == nil {
-		useTLS := true
-		if merged.UseTLS != nil {
-			useTLS = *merged.UseTLS
-		}
-		sender = smtp.NewSender(merged.SMTPHost, merged.SMTPPort, merged.SMTPUser, merged.SMTPPassword, useTLS)
+		sender = smtp.NewSender(merged.SMTPHost, merged.SMTPPort, merged.SMTPUser, merged.SMTPPassword, merged.SMTPTLSMode)
 	}
 	processor, err := output.NewEmailProcessor(merged, sender)
 	if err != nil {
@@ -161,9 +157,8 @@ func (f *Factory) mergeEmailConfig(cfg *config.EmailOutput) *config.EmailOutput 
 	if merged.SMTPPassword == "" {
 		merged.SMTPPassword = f.SMTPDefaults.Password
 	}
-	if merged.UseTLS == nil {
-		useTLS := f.SMTPDefaults.UseTLS
-		merged.UseTLS = &useTLS
+	if merged.SMTPTLSMode == "" {
+		merged.SMTPTLSMode = f.SMTPDefaults.TLSMode
 	}
 	return &merged
 }


### PR DESCRIPTION
### Motivation
- Simplify and make SMTP TLS behavior explicit by removing the legacy `use_tls` boolean and driving behavior via `smtp_tls_mode` with sensible port-based defaults. 
- Allow operators to explicitly request `starttls`, `implicit`, or `disabled` modes and avoid ambiguity for gateways that require STARTTLS on specific ports. 

### Description
- Remove `UseTLS`/`SMTP_USE_TLS` from config and env structs and replace with `SMTPTLSMode` / `SMTP_TLS_MODE` across `internal/config` and env loading. 
- Replace `NewSender(..., useTLS bool, ...)` with `NewSender(..., tlsMode string)` and add `TLSMode` constants with `parseTLSMode` and `resolveTLSMode` to normalize and apply port-based defaults. 
- Update SMTP send logic to map TLS modes to the mail client options (`NoTLS`, `TLSMandatory` for STARTTLS, or `WithSSL()` for implicit SMTPS). 
- Update factory wiring, tests (`internal/outputs/email/smtp`), e2e fixture, docker compose dev env, and documentation (`README.md`, `docs/curator_document_spec.md`) to use `smtp_tls_mode`. 

### Testing
- Ran `gofmt` on the modified Go files to ensure formatting, which completed successfully. 
- Added unit tests for `parseTLSMode` and `resolveTLSMode` under `internal/outputs/email/smtp`, intended to cover the new mode parsing and resolution logic. 
- Ran `go test ./... -count=1 -timeout=2m` to validate the code base, but the test run hung and was terminated, so full automated test results are incomplete.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6976f1b56870832c9f0ac1e47c29d40c)