### PR TITLE
Add SMTP option to skip TLS verification

### DIFF
--- a/internal/config/env.go
+++ b/internal/config/env.go
@@ -68,11 +68,12 @@ type RSSEnvConfig struct {
 }
 
 type SMTPEnvConfig struct {
-	Host     string
-	Port     int
-	User     string
-	Password string
-	TLSMode  string
+	Host               string
+	Port               int
+	User               string
+	Password           string
+	TLSMode            string
+	InsecureSkipVerify bool
 }
 
 func LoadEnv() EnvConfig {
@@ -131,11 +132,12 @@ func LoadEnv() EnvConfig {
 			UserAgent:   envString("RSS_USER_AGENT", "curator-ai/0.1"),
 		},
 		SMTP: SMTPEnvConfig{
-			Host:     envString("SMTP_HOST", ""),
-			Port:     envInt("SMTP_PORT", 587),
-			User:     envString("SMTP_USER", ""),
-			Password: envString("SMTP_PASSWORD", ""),
-			TLSMode:  envString("SMTP_TLS_MODE", ""),
+			Host:               envString("SMTP_HOST", ""),
+			Port:               envInt("SMTP_PORT", 587),
+			User:               envString("SMTP_USER", ""),
+			Password:           envString("SMTP_PASSWORD", ""),
+			TLSMode:            envString("SMTP_TLS_MODE", ""),
+			InsecureSkipVerify: envBool("SMTP_INSECURE_SKIP_VERIFY", false),
 		},
 	}
 }

--- a/internal/config/schema.go
+++ b/internal/config/schema.go
@@ -227,16 +227,17 @@ func (c *DedupeStoreConfig) UnmarshalYAML(value *yaml.Node) error {
 
 // EmailOutput defines email delivery configuration
 type EmailOutput struct {
-	Template     string               `yaml:"template"`
-	To           string               `yaml:"to"`
-	From         string               `yaml:"from"`
-	Subject      string               `yaml:"subject"`
-	SMTPHost     string               `yaml:"smtp_host,omitempty"`
-	SMTPPort     int                  `yaml:"smtp_port,omitempty"`
-	SMTPUser     string               `yaml:"smtp_user,omitempty"`
-	SMTPPassword string               `yaml:"smtp_password,omitempty"`
-	SMTPTLSMode  string               `yaml:"smtp_tls_mode,omitempty"`
-	Snapshot     *core.SnapshotConfig `yaml:"snapshot,omitempty"`
+	Template               string               `yaml:"template"`
+	To                     string               `yaml:"to"`
+	From                   string               `yaml:"from"`
+	Subject                string               `yaml:"subject"`
+	SMTPHost               string               `yaml:"smtp_host,omitempty"`
+	SMTPPort               int                  `yaml:"smtp_port,omitempty"`
+	SMTPUser               string               `yaml:"smtp_user,omitempty"`
+	SMTPPassword           string               `yaml:"smtp_password,omitempty"`
+	SMTPTLSMode            string               `yaml:"smtp_tls_mode,omitempty"`
+	SMTPInsecureSkipVerify *bool                `yaml:"smtp_insecure_skip_verify,omitempty"`
+	Snapshot               *core.SnapshotConfig `yaml:"snapshot,omitempty"`
 }
 
 // ProcessorType identifies the type of processor

--- a/internal/config/schema_test.go
+++ b/internal/config/schema_test.go
@@ -775,21 +775,23 @@ func TestParseToFlow(t *testing.T) {
 }
 
 func TestParseEmailOutputConfig(t *testing.T) {
+	skipVerify := true
 	doc := CuratorDocument{
 		Workflow: Workflow{
 			Name:    "Email Test",
 			Trigger: []TriggerConfig{{Cron: &CronTrigger{Schedule: "0 0 * * *"}}},
 			Sources: []SourceConfig{{Reddit: &RedditSource{Subreddits: []string{"test"}}}},
 			Output: []OutputConfig{{Email: &EmailOutput{
-				Template:     "test",
-				To:           "test@test.com",
-				From:         "noreply@test.com",
-				Subject:      "Test Subject",
-				SMTPHost:     "smtp.test.com",
-				SMTPPort:     2525,
-				SMTPUser:     "user",
-				SMTPPassword: "pass",
-				SMTPTLSMode:  "starttls",
+				Template:               "test",
+				To:                     "test@test.com",
+				From:                   "noreply@test.com",
+				Subject:                "Test Subject",
+				SMTPHost:               "smtp.test.com",
+				SMTPPort:               2525,
+				SMTPUser:               "user",
+				SMTPPassword:           "pass",
+				SMTPTLSMode:            "starttls",
+				SMTPInsecureSkipVerify: &skipVerify,
 			}}},
 		},
 	}
@@ -820,6 +822,9 @@ func TestParseEmailOutputConfig(t *testing.T) {
 	}
 	if emailConfig.SMTPTLSMode != "starttls" {
 		t.Errorf("Expected smtp_tls_mode starttls, got %q", emailConfig.SMTPTLSMode)
+	}
+	if emailConfig.SMTPInsecureSkipVerify == nil || !*emailConfig.SMTPInsecureSkipVerify {
+		t.Errorf("Expected smtp_insecure_skip_verify true, got %#v", emailConfig.SMTPInsecureSkipVerify)
 	}
 }
 

--- a/internal/runner/factory/factory.go
+++ b/internal/runner/factory/factory.go
@@ -131,7 +131,14 @@ func (f *Factory) NewEmailOutput(cfg *config.EmailOutput) (core.OutputProcessor,
 	merged := f.mergeEmailConfig(cfg)
 	sender := f.EmailSender
 	if sender == nil {
-		sender = smtp.NewSender(merged.SMTPHost, merged.SMTPPort, merged.SMTPUser, merged.SMTPPassword, merged.SMTPTLSMode)
+		sender = smtp.NewSender(
+			merged.SMTPHost,
+			merged.SMTPPort,
+			merged.SMTPUser,
+			merged.SMTPPassword,
+			merged.SMTPTLSMode,
+			merged.SMTPInsecureSkipVerify != nil && *merged.SMTPInsecureSkipVerify,
+		)
 	}
 	processor, err := output.NewEmailProcessor(merged, sender)
 	if err != nil {
@@ -159,6 +166,10 @@ func (f *Factory) mergeEmailConfig(cfg *config.EmailOutput) *config.EmailOutput 
 	}
 	if merged.SMTPTLSMode == "" {
 		merged.SMTPTLSMode = f.SMTPDefaults.TLSMode
+	}
+	if merged.SMTPInsecureSkipVerify == nil {
+		defaultSkipVerify := f.SMTPDefaults.InsecureSkipVerify
+		merged.SMTPInsecureSkipVerify = &defaultSkipVerify
 	}
 	return &merged
 }


### PR DESCRIPTION
### Motivation
- Allow connecting to SMTP servers using self-signed or otherwise invalid TLS certificates by making TLS cert verification optionally configurable.

### Description
- Added `SMTPInsecureSkipVerify *bool` to the email output config (`smtp_insecure_skip_verify` YAML) and `InsecureSkipVerify bool` to environment SMTP defaults (`SMTP_INSECURE_SKIP_VERIFY`).
- Propagated the setting through `Factory.mergeEmailConfig` and `NewEmailOutput` and updated the SMTP sender constructor to `NewSender(..., insecureSkipVerify bool)`.
- Applied the flag to the SMTP client's TLS configuration via `tls.Config{InsecureSkipVerify: ...}` so verification is skipped only when explicitly enabled, and updated `internal/config/schema_test.go` to cover the new option.

### Testing
- Ran `go test ./...`, tests passed for the repository packages (tests are cached/ok for relevant packages).
- Ran `gofmt` to format changes.
- Ran `go vet ./...`, which reported an unrelated issue: unreachable code in `internal/processors/quality/llm.go:292` (not introduced by this change).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69775d4a1224832c91db598831d2f260)