### PR TITLE
Add arXiv test curator doc

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 .gopath
 .gotmp
 curator-seen.db
+snapshots/
 
 # Build artifacts
 /bin/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -59,6 +59,7 @@ This file is intentionally a short index. The authoritative behavior and design 
 ## Coding Standards (Project-Specific)
 
 - Comments, comments comments. Comment functions and use comments to explain the behaviour of blocks of code and why they should do that.
+- Use `logger` to log activity during a run. This ensures that the current state of processing is understood.
 - Keep configuration/env access centralized in [internal/config/env.go](internal/config/env.go) (avoid sprinkling `os.Getenv`).
 - Prefer the existing processor pattern:
   - add schema config in [internal/config/schema.go](internal/config/schema.go)

--- a/README.md
+++ b/README.md
@@ -36,6 +36,9 @@ go run ./cmd/curator -config curator.yaml -run-once
 - `REDDIT_PASSWORD` (optional; required with `REDDIT_USERNAME`)
 - `RSS_HTTP_TIMEOUT` (optional, e.g. `10s`)
 - `RSS_USER_AGENT` (optional, default: `curator-ai/0.1`)
+- `ARXIV_BASE_URL` (optional, default: `https://export.arxiv.org/api/query`)
+- `ARXIV_HTTP_TIMEOUT` (optional, e.g. `10s`)
+- `ARXIV_USER_AGENT` (optional, default: `curator-ai/0.1`)
 
 ### Jina Reader (URL → markdown)
 - `JINA_API_KEY` (required to use the Jina Reader client)

--- a/curator-docs/testing-docs/arxiv.yaml
+++ b/curator-docs/testing-docs/arxiv.yaml
@@ -81,7 +81,7 @@ workflow:
         snapshot:
           snapshot: true
           # restore: true
-          path: "snapshots/run-summary.json"
+          path: "snapshots/arxiv-run-summary.json"
     - markdown:
         name: markdown_to_html_sum
         type: markdown

--- a/curator-docs/testing-docs/arxiv.yaml
+++ b/curator-docs/testing-docs/arxiv.yaml
@@ -1,0 +1,25 @@
+workflow:
+  name: "arxiv-test"
+  trigger:
+    - cron:
+        schedule: "0 0 * * *"
+  sources:
+    - arxiv:
+        query: "retrieval augmented generation"
+        categories: ["cs.CL", "cs.IR"]
+        max_results: 5
+        sort_by: "lastUpdatedDate"
+        sort_order: "descending"
+        include_abstract_in_chunks: true
+        chunking:
+          mode: "section"
+          fallback_max_chars: 3500
+          min_section_chars: 400
+        summary_plan:
+          mode: per_chunk
+  output:
+    - email:
+        template: "Hello"
+        to: "test@example.com"
+        from: "noreply@example.com"
+        subject: "Daily Report"

--- a/curator-docs/testing-docs/arxiv.yaml
+++ b/curator-docs/testing-docs/arxiv.yaml
@@ -5,8 +5,8 @@ workflow:
         schedule: "0 0 * * *"
   sources:
     - arxiv:
-        query: "retrieval augmented generation"
-        categories: ["cs.CL", "cs.IR"]
+        # query: ""
+        categories: ["cs.CR"]
         max_results: 5
         sort_by: "lastUpdatedDate"
         sort_order: "descending"
@@ -16,10 +16,150 @@ workflow:
           fallback_max_chars: 3500
           min_section_chars: 400
         summary_plan:
-          mode: per_chunk
+          mode: map_reduce
+        snapshot:
+          snapshot: true
+          # restore: true
+          path: "snapshots/arxiv.json"
+
+  quality:
+    - llm:
+        name: is_relevant
+        prompt_template: isRelevantTemplate
+        evaluations:
+          - "Is focused on AI or Large Language Model secutiy, or it's use in security"
+        action_type: pass_drop
+        threshold: 0.5 # optional
+        # block_error_policy: drop
+        block_error_policy: fail
+        snapshot:
+          snapshot: true
+          # restore: true
+          path: "snapshots/arxiv-quality-llm.json"
+
+  post_summary:
+    - llm:
+        name: post_sum
+        type: llm
+        context: post
+        prompt_template: postSummaryTemplate
+        params:
+          interests:
+            - "AI and Large Language Model Security"
+        chunk_system_template: |-
+          You are a helpful assistant that summarizes a document chunk. You are provided an abstract for a paper, alongside a chunk. You should try to provide a high level overview of what's in that chunk, in a way that can by synthersised into a full summary of the paper. Do not summarise the abstract, it is intended to provide context on what the paper is about.
+
+          Always summarise in markdown and provide the summarisation directly.
+        chunk_prompt_template: |-
+          Summarize the following chunk:
+          {{.Chunk.Content}}
+        snapshot:
+          snapshot: true
+          # restore: true
+          path: "snapshots/arxiv-post-summary.json"
+    - markdown:
+        name: markdown_to_html_post_sum
+        type: markdown
+        context: post
+
   output:
     - email:
-        template: "Hello"
-        to: "test@example.com"
-        from: "noreply@example.com"
-        subject: "Daily Report"
+        template: emailTemplate
+        to: brandon@bdmd.com.au
+        subject: "Paper Test"
+
+templates:
+  - id: postSummaryTemplate
+    system_template: |-
+      You are an expert security and AI analyst.
+
+      Write a concise summary of the post. Focus on the reader interests.
+      Keep it factual, and include concrete details (numbers, model names, benchmarks) when present.
+      When comments are present, summarise the community response.
+
+      Reader interests:
+      {{- range (index .Params "interests") }}
+      - {{ . }}
+      {{- end }}
+
+      Output format:
+      - One sentence summary of the paper
+      - 3-6 bullet points
+      - then "Why it matters:" (1-2 sentences)
+      - then "Key entities:" (comma-separated list)
+
+      Don't add any additional comments that stray from the output format. Use markdown, do not include code fences.
+
+    template: |-
+      -----USER CONTENT START-----
+      Post:
+      Title: {{ .Title }}
+      URL: {{ .URL }}
+      Author: {{ .Author }}
+
+      Content:
+      {{ .ChunkSummaries }}
+      -----USER CONTENT END-----
+
+  - id: emailTemplate
+    system_template: "--" # Email is still considered a prompt template right now
+    template: |-
+      <!doctype html>
+      <html>
+        <body style="margin:0;padding:0;background:#ffffff;">
+        {{- range .Blocks }}
+        <div style="padding:12px 0;border-top:1px solid #e5e5e5;">
+          <div style="font-size:15px;font-weight:700;margin:0 0 4px 0;">
+            <a href="{{ .URL }}" style="color:#111;text-decoration:underline;">{{ .Title }}</a>
+            <div style="font-size:13px;margin:0;">
+              {{- if .Summary }}
+              {{ .Summary.HTML }}
+              {{- else }}
+              {{ .Content }}
+              {{- end }}
+            </div>
+          </div>
+        </div>
+        {{- end }}
+
+  - id: isRelevantTemplate
+    system_template: |-
+      You are a strict relevance/quality evaluator.
+
+      You may be given post text plus one or more images attached as multimodal inputs.
+      Use images as primary evidence when the post text is sparse. If charts/tables are present, extract key numbers and units.
+
+      Evaluate the post and output ONLY valid JSON with this exact shape:
+      {"score": <number 0..1>, "reason": <string>}
+
+      Scoring guidance:
+      - 0.0 = completely irrelevant / low-signal
+      - 1.0 = extremely relevant / high-signal
+
+      Positive evaluation criteria (score higher when these apply):
+      {{- range .Evaluations }}
+      - {{ . }}
+      {{- end }}
+
+      {{- if .Exclusions }}
+      Exclusion criteria (score near 0 when these apply):
+      {{- range .Exclusions }}
+      - {{ . }}
+      {{- end }}
+      {{- end }}
+
+      Reason should be a single sentence of 25 words or less.
+
+      Return ONLY the JSON object. No markdown, no code fences, no json```
+    template: |-
+      -----USER CONTENT START-----
+      Post:
+      Title: {{ .Title }}
+      URL: {{ .URL }}
+      Author: {{ .Author }}
+      CreatedAt: {{ .CreatedAt }}
+
+      Content:
+      {{ .Content }}
+      -----USER CONTENT END-----
+

--- a/curator-docs/testing-docs/arxiv.yaml
+++ b/curator-docs/testing-docs/arxiv.yaml
@@ -1,22 +1,32 @@
 workflow:
-  name: "arxiv-test"
+  name: "LLM Security Papers"
+  max_concurrency: 20
+  # dedupe_store:
+  #   driver: "sqlite"
+  #   dsn: "./curator-seen.db"
+  #   table: "seen_posts"
+  #   ttl: "365d"
+
   trigger:
     - cron:
         schedule: "0 0 * * *"
+
   sources:
     - arxiv:
         # query: ""
         categories: ["cs.CR"]
-        max_results: 5
+        max_results: 50
         sort_by: "lastUpdatedDate"
         sort_order: "descending"
-        include_abstract_in_chunks: true
-        chunking:
-          mode: "section"
-          fallback_max_chars: 3500
-          min_section_chars: 400
-        summary_plan:
-          mode: map_reduce
+        # When true, PostBlock.Content is only the abstract (no full-text fetch).
+        abstract_only: true
+        # include_abstract_in_chunks: true
+        # chunking:
+        #   mode: "section"
+        #   fallback_max_chars: 3500
+        #   min_section_chars: 400
+        # summary_plan:
+        #   mode: map_reduce
         snapshot:
           snapshot: true
           # restore: true
@@ -27,7 +37,9 @@ workflow:
         name: is_relevant
         prompt_template: isRelevantTemplate
         evaluations:
-          - "Is focused on AI or Large Language Model secutiy, or it's use in security"
+          - "Is focused on the application of LLMs or AI on cybersecurity"
+          - "Novel uses of LLMs or AI in penetration testing or cyber defence"
+          - "Advances in custom models focused on cybersecurity"
         action_type: pass_drop
         threshold: 0.5 # optional
         # block_error_policy: drop
@@ -46,13 +58,6 @@ workflow:
         params:
           interests:
             - "AI and Large Language Model Security"
-        chunk_system_template: |-
-          You are a helpful assistant that summarizes a document chunk. You are provided an abstract for a paper, alongside a chunk. You should try to provide a high level overview of what's in that chunk, in a way that can by synthersised into a full summary of the paper. Do not summarise the abstract, it is intended to provide context on what the paper is about.
-
-          Always summarise in markdown and provide the summarisation directly.
-        chunk_prompt_template: |-
-          Summarize the following chunk:
-          {{.Chunk.Content}}
         snapshot:
           snapshot: true
           # restore: true
@@ -62,6 +67,26 @@ workflow:
         type: markdown
         context: post
 
+  run_summary:
+    - llm:
+        name: full_sum
+        type: llm
+        context: flow
+        prompt_template: fullSummaryTemplate
+        params:
+          focus:
+            - "Novel attack vectors against LLMs"
+            - "LLM use in security research, penetration testing or defence"
+        block_error_policy: fail
+        snapshot:
+          snapshot: true
+          # restore: true
+          path: "snapshots/run-summary.json"
+    - markdown:
+        name: markdown_to_html_sum
+        type: markdown
+        context: "flow"
+
   output:
     - email:
         template: emailTemplate
@@ -69,59 +94,6 @@ workflow:
         subject: "Paper Test"
 
 templates:
-  - id: postSummaryTemplate
-    system_template: |-
-      You are an expert security and AI analyst.
-
-      Write a concise summary of the post. Focus on the reader interests.
-      Keep it factual, and include concrete details (numbers, model names, benchmarks) when present.
-      When comments are present, summarise the community response.
-
-      Reader interests:
-      {{- range (index .Params "interests") }}
-      - {{ . }}
-      {{- end }}
-
-      Output format:
-      - One sentence summary of the paper
-      - 3-6 bullet points
-      - then "Why it matters:" (1-2 sentences)
-      - then "Key entities:" (comma-separated list)
-
-      Don't add any additional comments that stray from the output format. Use markdown, do not include code fences.
-
-    template: |-
-      -----USER CONTENT START-----
-      Post:
-      Title: {{ .Title }}
-      URL: {{ .URL }}
-      Author: {{ .Author }}
-
-      Content:
-      {{ .ChunkSummaries }}
-      -----USER CONTENT END-----
-
-  - id: emailTemplate
-    system_template: "--" # Email is still considered a prompt template right now
-    template: |-
-      <!doctype html>
-      <html>
-        <body style="margin:0;padding:0;background:#ffffff;">
-        {{- range .Blocks }}
-        <div style="padding:12px 0;border-top:1px solid #e5e5e5;">
-          <div style="font-size:15px;font-weight:700;margin:0 0 4px 0;">
-            <a href="{{ .URL }}" style="color:#111;text-decoration:underline;">{{ .Title }}</a>
-            <div style="font-size:13px;margin:0;">
-              {{- if .Summary }}
-              {{ .Summary.HTML }}
-              {{- else }}
-              {{ .Content }}
-              {{- end }}
-            </div>
-          </div>
-        </div>
-        {{- end }}
-
   - id: isRelevantTemplate
     system_template: |-
       You are a strict relevance/quality evaluator.
@@ -159,7 +131,115 @@ templates:
       Author: {{ .Author }}
       CreatedAt: {{ .CreatedAt }}
 
-      Content:
+      Abstract:
       {{ .Content }}
       -----USER CONTENT END-----
+
+  - id: postSummaryTemplate
+    system_template: |-
+      You are an expert security and AI analyst.
+
+      Write a concise summary of the post. Focus on the reader interests.
+      Keep it factual, and include concrete details (numbers, model names, benchmarks) when present.
+      When comments are present, summarise the community response.
+
+      Reader interests:
+      {{- range (index .Params "interests") }}
+      - {{ . }}
+      {{- end }}
+
+      Output format:
+      - One sentence summary of the paper
+      - 3-6 bullet points
+      - then "Why it matters:" (1-2 sentences)
+      - then "Key entities:" (comma-separated list)
+
+      Don't add any additional comments that stray from the output format. Use markdown, do not include code fences.
+
+    template: |-
+      -----USER CONTENT START-----
+      Post:
+      Title: {{ .Title }}
+      URL: {{ .URL }}
+      Author: {{ .Author }}
+
+      Content:
+      {{ .ChunkSummaries }}
+      -----USER CONTENT END-----
+
+  - id: fullSummaryTemplate
+    system_template: |-
+      You are writing an aggregate digest across multiple posts.
+
+      Produce an executive summary, then group notable items.
+
+      Include an:
+      - Executive summary, focused on 4-8 bullet points
+      - Notable Items, pick 5 most relevant items to the focus area, bulleted, include post title + 1 sentence
+
+      Focus areas:
+      {{- range (index .Params "focus") }}
+      - {{ . }}
+      {{- end }}
+
+      Output format:
+      # Executive summary
+      # Notable items
+
+    template: |-
+      There are {{ len .Blocks }} posts.
+
+      Posts:
+      {{- range $i, $p := .Blocks }}
+      ---
+      Title: {{ $p.Title }}
+      URL: {{ $p.URL }}
+      Author: {{ $p.Author }}
+      Post summary (if present): {{- if $p.Summary }}
+      {{ $p.Summary.Summary }}
+      {{- else }}
+      (none)
+      {{- end }}
+      {{- end }}
+
+
+
+  - id: emailTemplate
+    system_template: "--" # Email is still considered a prompt template right now
+    template: |-
+      <!doctype html>
+        <html>
+          <body style="margin:0;padding:0;background:#ffffff;">
+            <div style="max-width:720px;margin:0 auto;padding:16px;font-family:Arial,Helvetica,sans-serif;color:#111;line-height:1.4;">
+              <h1 style="margin:0 0 12px 0;font-size:22px;">LLM Research Papers</h1>
+
+              {{- if .RunSummary }}
+              {{- .RunSummary.HTML }}
+              {{- end }}
+
+              <h2 style="margin:16px 0 8px 0;font-size:16px;">Posts ({{ len .Blocks }})</h2>
+
+              {{- range .Blocks }}
+              <div style="padding:12px 0;border-top:1px solid #e5e5e5;">
+                <div style="font-size:15px;font-weight:700;margin:0 0 4px 0;">
+                  <a href="{{ .URL }}" style="color:#111;text-decoration:underline;">{{ .Title }}</a>
+                </div>
+
+                <div style="font-size:12px;color:#666;margin:0 0 8px 0;">
+                  <a href="{{ .URL }}" style="color:#666;text-decoration:none;">{{ .URL }}</a>
+                </div>
+
+                <div style="font-size:13px;margin:0;">
+                  {{- if .Summary }}
+                  {{ .Summary.HTML }}
+                  {{- else }}
+                  (no summary)
+                  {{- end }}
+                </div>
+              </div>
+              {{- end }}
+            </div>
+          </body>
+        </html>
+
 

--- a/docs/curator_document_spec.md
+++ b/docs/curator_document_spec.md
@@ -89,6 +89,26 @@ reddit:
   min_score: number              # Optional: Minimum post score filter
 ```
 
+#### arXiv Source
+Fetches papers from arXiv and emits each paper as a `PostBlock`.
+
+```yaml
+arxiv:
+  query: string                         # Optional when categories provided
+  categories: [string]                  # Optional when query provided (e.g. ["cs.LG"])
+  max_results: number                   # Optional: max papers to fetch
+  sort_by: string                       # Optional: "relevance" | "lastUpdatedDate" | "submittedDate"
+  sort_order: string                    # Optional: "ascending" | "descending"
+  date_from: string                     # Optional: YYYY-MM-DD
+  date_to: string                       # Optional: YYYY-MM-DD
+  abstract_only: boolean                # Optional: when true, PostBlock.Content is abstract-only
+  include_abstract_in_chunks: boolean   # Optional: include abstract prefix on chunk text
+  chunking:
+    mode: string                        # Optional: "section" | "size"
+    fallback_max_chars: number          # Optional: max chars per chunk in size fallback
+    min_section_chars: number           # Optional: merge tiny sections below this size
+```
+
 ### Quality Processors
 
 #### Quality Rule

--- a/internal/config/env.go
+++ b/internal/config/env.go
@@ -17,6 +17,7 @@ type EnvConfig struct {
 	OpenAI                   OpenAIEnvConfig
 	OTel                     OTelEnvConfig
 	Jina                     JinaEnvConfig
+	Arxiv                    ArxivEnvConfig
 	Reddit                   RedditEnvConfig
 	RSS                      RSSEnvConfig
 	SMTP                     SMTPEnvConfig
@@ -48,6 +49,12 @@ type OTelEnvConfig struct {
 
 type JinaEnvConfig struct {
 	APIKey      string
+	BaseURL     string
+	HTTPTimeout time.Duration
+	UserAgent   string
+}
+
+type ArxivEnvConfig struct {
 	BaseURL     string
 	HTTPTimeout time.Duration
 	UserAgent   string
@@ -118,6 +125,11 @@ func LoadEnv() EnvConfig {
 			BaseURL:     strings.TrimSpace(envString("JINA_BASE_URL", "")),
 			HTTPTimeout: envDuration("JINA_HTTP_TIMEOUT", 15*time.Second),
 			UserAgent:   envString("JINA_USER_AGENT", "curator-ai/0.1"),
+		},
+		Arxiv: ArxivEnvConfig{
+			BaseURL:     strings.TrimSpace(envString("ARXIV_BASE_URL", "")),
+			HTTPTimeout: envDuration("ARXIV_HTTP_TIMEOUT", 10*time.Second),
+			UserAgent:   envString("ARXIV_USER_AGENT", "curator-ai/0.1"),
 		},
 		Reddit: RedditEnvConfig{
 			HTTPTimeout:  envDuration("REDDIT_HTTP_TIMEOUT", 10*time.Second),

--- a/internal/config/schema.go
+++ b/internal/config/schema.go
@@ -91,6 +91,9 @@ type ArxivSource struct {
 	SortOrder               string               `yaml:"sort_order,omitempty"`
 	DateFrom                string               `yaml:"date_from,omitempty"`
 	DateTo                  string               `yaml:"date_to,omitempty"`
+	// AbstractOnly forces PostBlock content/chunks to be built from the abstract only.
+	// When enabled, the processor skips full-text fetches via Jina.
+	AbstractOnly            *bool                `yaml:"abstract_only,omitempty"`
 	IncludeAbstractInChunks *bool                `yaml:"include_abstract_in_chunks,omitempty"`
 	Chunking                *ArxivChunkingConfig `yaml:"chunking,omitempty"`
 	SummaryPlan             *SummaryPlanConfig   `yaml:"summary_plan,omitempty"`

--- a/internal/config/schema.go
+++ b/internal/config/schema.go
@@ -53,6 +53,7 @@ type CronTrigger struct {
 type SourceConfig struct {
 	Reddit   *RedditSource   `yaml:"reddit,omitempty"`
 	RSS      *RSSSource      `yaml:"rss,omitempty"`
+	Arxiv    *ArxivSource    `yaml:"arxiv,omitempty"`
 	TestFile *TestFileSource `yaml:"testfile,omitempty"`
 }
 
@@ -79,6 +80,28 @@ type RSSSource struct {
 	UserAgent               string               `yaml:"user_agent,omitempty"`
 	SummaryPlan             *SummaryPlanConfig   `yaml:"summary_plan,omitempty"`
 	Snapshot                *core.SnapshotConfig `yaml:"snapshot,omitempty"`
+}
+
+// ArxivSource defines arXiv API configuration for paper discovery and ingestion.
+type ArxivSource struct {
+	Query                   string               `yaml:"query,omitempty"`
+	Categories              []string             `yaml:"categories,omitempty"`
+	MaxResults              int                  `yaml:"max_results,omitempty"`
+	SortBy                  string               `yaml:"sort_by,omitempty"`
+	SortOrder               string               `yaml:"sort_order,omitempty"`
+	DateFrom                string               `yaml:"date_from,omitempty"`
+	DateTo                  string               `yaml:"date_to,omitempty"`
+	IncludeAbstractInChunks *bool                `yaml:"include_abstract_in_chunks,omitempty"`
+	Chunking                *ArxivChunkingConfig `yaml:"chunking,omitempty"`
+	SummaryPlan             *SummaryPlanConfig   `yaml:"summary_plan,omitempty"`
+	Snapshot                *core.SnapshotConfig `yaml:"snapshot,omitempty"`
+}
+
+// ArxivChunkingConfig controls how arXiv paper content is split into chunks.
+type ArxivChunkingConfig struct {
+	Mode             string `yaml:"mode,omitempty"`
+	FallbackMaxChars int    `yaml:"fallback_max_chars,omitempty"`
+	MinSectionChars  int    `yaml:"min_section_chars,omitempty"`
 }
 
 // SummaryPlanConfig declares how summary processors should handle a post.
@@ -299,6 +322,7 @@ type ProcessorFactory interface {
 	NewCronTrigger(config *CronTrigger) (core.TriggerProcessor, error)
 	NewRedditSource(config *RedditSource) (core.SourceProcessor, error)
 	NewRSSSource(config *RSSSource) (core.SourceProcessor, error)
+	NewArxivSource(config *ArxivSource) (core.SourceProcessor, error)
 	NewTestFileSource(config *TestFileSource) (core.SourceProcessor, error)
 	NewQualityRule(config *QualityRule) (core.QualityProcessor, error)
 	NewLLMQuality(config *LLMQuality) (core.QualityProcessor, error)
@@ -384,7 +408,7 @@ func (d *CuratorDocument) Validate() error {
 
 	// Validate sources
 	for i, source := range d.Workflow.Sources {
-		if source.Reddit == nil && source.RSS == nil && source.TestFile == nil {
+		if source.Reddit == nil && source.RSS == nil && source.Arxiv == nil && source.TestFile == nil {
 			return fmt.Errorf("source %d: unsupported source type", i)
 		}
 		if source.Reddit != nil && len(source.Reddit.Subreddits) == 0 {
@@ -392,6 +416,9 @@ func (d *CuratorDocument) Validate() error {
 		}
 		if source.RSS != nil && len(source.RSS.Feeds) == 0 {
 			return fmt.Errorf("source %d: at least one rss feed is required", i)
+		}
+		if source.Arxiv != nil && strings.TrimSpace(source.Arxiv.Query) == "" && len(source.Arxiv.Categories) == 0 {
+			return fmt.Errorf("source %d: arxiv requires query or categories", i)
 		}
 		if source.TestFile != nil && strings.TrimSpace(source.TestFile.Path) == "" {
 			return fmt.Errorf("source %d: testfile path is required", i)
@@ -409,6 +436,14 @@ func (d *CuratorDocument) Validate() error {
 				return err
 			}
 			if err := validateSnapshotConfig(fmt.Sprintf("source %d rss", i), source.RSS.Snapshot); err != nil {
+				return err
+			}
+		}
+		if source.Arxiv != nil {
+			if err := validateSummaryPlanConfig(fmt.Sprintf("source %d arxiv", i), source.Arxiv.SummaryPlan); err != nil {
+				return err
+			}
+			if err := validateSnapshotConfig(fmt.Sprintf("source %d arxiv", i), source.Arxiv.Snapshot); err != nil {
 				return err
 			}
 		}
@@ -944,6 +979,24 @@ func (d *CuratorDocument) ParseToFlowWithFactory(factory ProcessorFactory) (*cor
 
 			processRef := core.ProcessReference{
 				Name:   "rss",
+				Type:   core.SourceProcessorType,
+				Source: sourceProcessor,
+			}
+			flow.OrderOfOperations = append(flow.OrderOfOperations, processRef)
+		}
+		if source.Arxiv != nil {
+			var sourceProcessor core.SourceProcessor
+			if factory != nil {
+				var err error
+				sourceProcessor, err = factory.NewArxivSource(source.Arxiv)
+				if err != nil {
+					return nil, err
+				}
+			}
+			flow.Sources = append(flow.Sources, sourceProcessor)
+
+			processRef := core.ProcessReference{
+				Name:   "arxiv",
 				Type:   core.SourceProcessorType,
 				Source: sourceProcessor,
 			}

--- a/internal/config/schema.go
+++ b/internal/config/schema.go
@@ -290,6 +290,7 @@ const (
 	ProcessorTriggerCron   ProcessorType = "trigger_cron"
 	ProcessorSourceReddit  ProcessorType = "source_reddit"
 	ProcessorSourceRSS     ProcessorType = "source_rss"
+	ProcessorSourceArxiv   ProcessorType = "source_arxiv"
 	ProcessorSourceTest    ProcessorType = "source_testfile"
 	ProcessorQualityRule   ProcessorType = "quality_rule"
 	ProcessorQualityLLM    ProcessorType = "quality_llm"
@@ -812,6 +813,13 @@ func (d *CuratorDocument) Parse() (*ParsedFlow, error) {
 				Type:   ProcessorSourceRSS,
 				Name:   "rss",
 				Config: source.RSS,
+			})
+		}
+		if source.Arxiv != nil {
+			flow.Sources = append(flow.Sources, ParsedProcessor{
+				Type:   ProcessorSourceArxiv,
+				Name:   "arxiv",
+				Config: source.Arxiv,
 			})
 		}
 		if source.TestFile != nil {

--- a/internal/config/schema_test.go
+++ b/internal/config/schema_test.go
@@ -207,6 +207,48 @@ workflow:
 	}
 }
 
+func TestParse_IncludesArxivSourceProcessor(t *testing.T) {
+	data := []byte(`
+workflow:
+  name: "Test Flow"
+  trigger:
+    - cron:
+        schedule: "0 0 * * *"
+  sources:
+    - arxiv:
+        query: "retrieval"
+  output:
+    - email:
+        template: "Hello"
+        to: "test@example.com"
+        from: "noreply@example.com"
+        subject: "Daily Report"
+`)
+
+	var doc CuratorDocument
+	if err := yaml.Unmarshal(data, &doc); err != nil {
+		t.Fatalf("Failed to unmarshal YAML: %v", err)
+	}
+
+	flow, err := doc.Parse()
+	if err != nil {
+		t.Fatalf("Failed to parse document: %v", err)
+	}
+
+	if len(flow.Sources) != 1 {
+		t.Fatalf("Expected 1 source processor, got %d", len(flow.Sources))
+	}
+	if flow.Sources[0].Type != ProcessorSourceArxiv {
+		t.Fatalf("Expected source type %q, got %q", ProcessorSourceArxiv, flow.Sources[0].Type)
+	}
+	if flow.Sources[0].Name != "arxiv" {
+		t.Fatalf("Expected source name %q, got %q", "arxiv", flow.Sources[0].Name)
+	}
+	if _, ok := flow.Sources[0].Config.(*ArxivSource); !ok {
+		t.Fatalf("Expected source config type *ArxivSource, got %T", flow.Sources[0].Config)
+	}
+}
+
 func TestTemplateTypeCheckFailsOnBadRunSummaryTemplate(t *testing.T) {
 	data := []byte(`
 workflow:

--- a/internal/config/schema_test.go
+++ b/internal/config/schema_test.go
@@ -154,6 +154,59 @@ workflow:
 	}
 }
 
+func TestValidate_ArxivRequiresQueryOrCategories(t *testing.T) {
+	data := []byte(`
+workflow:
+  name: "Test Flow"
+  trigger:
+    - cron:
+        schedule: "0 0 * * *"
+  sources:
+    - arxiv: {}
+  output:
+    - email:
+        template: "Hello"
+        to: "test@example.com"
+        from: "noreply@example.com"
+        subject: "Daily Report"
+`)
+
+	var doc CuratorDocument
+	if err := yaml.Unmarshal(data, &doc); err != nil {
+		t.Fatalf("Failed to unmarshal YAML: %v", err)
+	}
+	if err := doc.Validate(); err == nil {
+		t.Fatalf("Expected validation to fail without arxiv query or categories")
+	}
+}
+
+func TestValidate_AllowsArxivQuery(t *testing.T) {
+	data := []byte(`
+workflow:
+  name: "Test Flow"
+  trigger:
+    - cron:
+        schedule: "0 0 * * *"
+  sources:
+    - arxiv:
+        query: "retrieval"
+  output:
+    - email:
+        template: "Hello"
+        to: "test@example.com"
+        from: "noreply@example.com"
+        subject: "Daily Report"
+`)
+
+	var doc CuratorDocument
+	if err := yaml.Unmarshal(data, &doc); err != nil {
+		t.Fatalf("Failed to unmarshal YAML: %v", err)
+	}
+	if err := doc.Validate(); err != nil {
+		t.Fatalf("Document validation failed: %v", err)
+	}
+}
+
 func TestTemplateTypeCheckFailsOnBadRunSummaryTemplate(t *testing.T) {
 	data := []byte(`
 workflow:
@@ -912,6 +965,10 @@ func (m *mockFactory) NewRedditSource(config *RedditSource) (core.SourceProcesso
 }
 
 func (m *mockFactory) NewRSSSource(config *RSSSource) (core.SourceProcessor, error) {
+	return &mockSource{}, nil
+}
+
+func (m *mockFactory) NewArxivSource(config *ArxivSource) (core.SourceProcessor, error) {
 	return &mockSource{}, nil
 }
 

--- a/internal/processors/llmutil/llmutil.go
+++ b/internal/processors/llmutil/llmutil.go
@@ -2,6 +2,7 @@ package llmutil
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"strings"
 	"text/template"
@@ -10,6 +11,57 @@ import (
 )
 
 type ResponseDecoder func(content string) error
+
+// UnmarshalJSONResponse unmarshals JSON from an LLM response.
+// It accepts either raw JSON content or JSON wrapped in a markdown code fence.
+func UnmarshalJSONResponse(content string, v any) error {
+	trimmed := strings.TrimSpace(content)
+	if err := json.Unmarshal([]byte(trimmed), v); err == nil {
+		return nil
+	}
+
+	fenced, ok := extractCodeFenceContent(trimmed)
+	if !ok {
+		return json.Unmarshal([]byte(trimmed), v)
+	}
+	return json.Unmarshal([]byte(fenced), v)
+}
+
+// extractCodeFenceContent extracts the first markdown code fence body that is either:
+// - explicitly labeled as json (```json), or
+// - unlabeled (```), for compatibility with model responses that omit language hints.
+func extractCodeFenceContent(content string) (string, bool) {
+	const fence = "```"
+	remaining := content
+
+	for {
+		start := strings.Index(remaining, fence)
+		if start < 0 {
+			return "", false
+		}
+		remaining = remaining[start+len(fence):]
+
+		lineEnd := strings.IndexByte(remaining, '\n')
+		if lineEnd < 0 {
+			return "", false
+		}
+
+		info := strings.TrimSpace(remaining[:lineEnd])
+		bodyStart := lineEnd + 1
+		bodyEndRel := strings.Index(remaining[bodyStart:], fence)
+		if bodyEndRel < 0 {
+			return "", false
+		}
+
+		bodyEnd := bodyStart + bodyEndRel
+		body := strings.TrimSpace(remaining[bodyStart:bodyEnd])
+		remaining = remaining[bodyEnd+len(fence):]
+
+		if info == "" || strings.EqualFold(info, "json") {
+			return body, true
+		}
+	}
+}
 
 func ParseSystemAndPromptTemplates(name, systemTemplate, promptTemplate string) (*template.Template, *template.Template, error) {
 	if name == "" {

--- a/internal/processors/llmutil/llmutil_json_test.go
+++ b/internal/processors/llmutil/llmutil_json_test.go
@@ -1,0 +1,61 @@
+package llmutil
+
+import "testing"
+
+func TestUnmarshalJSONResponse(t *testing.T) {
+	t.Parallel()
+
+	type payload struct {
+		Score  float64 `json:"score"`
+		Reason string  `json:"reason"`
+	}
+
+	tests := []struct {
+		name    string
+		content string
+		wantErr bool
+	}{
+		{
+			name:    "raw json",
+			content: `{"score":0.7,"reason":"ok"}`,
+		},
+		{
+			name:    "json code fence",
+			content: "```json\n{\"score\":0.7,\"reason\":\"ok\"}\n```",
+		},
+		{
+			name:    "plain code fence",
+			content: "```\n{\"score\":0.7,\"reason\":\"ok\"}\n```",
+		},
+		{
+			name:    "invalid json in code fence",
+			content: "```json\nnot-json\n```",
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			var got payload
+			err := UnmarshalJSONResponse(tt.content, &got)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("expected error, got nil")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("expected nil error, got %v", err)
+			}
+			if got.Score != 0.7 {
+				t.Fatalf("expected score 0.7, got %f", got.Score)
+			}
+			if got.Reason != "ok" {
+				t.Fatalf("expected reason ok, got %q", got.Reason)
+			}
+		})
+	}
+}

--- a/internal/processors/quality/llm.go
+++ b/internal/processors/quality/llm.go
@@ -2,7 +2,6 @@ package quality
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"log/slog"
 	"sync"
@@ -164,7 +163,7 @@ func (p *LLMProcessor) Evaluate(ctx context.Context, blocks []*core.PostBlock) (
 					{Role: llm.RoleSystem, Content: system_prompt},
 					userMessage,
 				}, decodeRetries, func(content string) error {
-					return json.Unmarshal([]byte(content), &parsed)
+					return llmutil.UnmarshalJSONResponse(content, &parsed)
 				}, temperature)
 				if err == nil {
 					break
@@ -196,7 +195,7 @@ func (p *LLMProcessor) Evaluate(ctx context.Context, blocks []*core.PostBlock) (
 				user_prompt,
 				decodeRetries,
 				func(content string) error {
-					return json.Unmarshal([]byte(content), &parsed)
+					return llmutil.UnmarshalJSONResponse(content, &parsed)
 				},
 				temperature,
 			)

--- a/internal/processors/quality/llm_retry_test.go
+++ b/internal/processors/quality/llm_retry_test.go
@@ -47,3 +47,40 @@ func TestLLMProcessor_RetriesOnInvalidJSON(t *testing.T) {
 		t.Fatalf("expected block to pass quality, got: %#v", blocks[0].Quality)
 	}
 }
+
+func TestLLMProcessor_ParsesJSONCodeFence(t *testing.T) {
+	t.Parallel()
+
+	cfg := &config.LLMQuality{
+		Name:               "q",
+		Model:              "test-model",
+		SystemTemplate:     "system",
+		PromptTemplate:     "title={{.Title}}",
+		Threshold:          0.5,
+		InvalidJSONRetries: 0,
+	}
+	client := &llmmock.Client{
+		Responses: []llm.ChatResponse{
+			{Content: "```json\n{\"score\":0.9,\"reason\":\"ok\"}\n```"},
+		},
+	}
+	processor, err := NewLLMProcessor(cfg, client, "default-model")
+	if err != nil {
+		t.Fatalf("NewLLMProcessor error: %v", err)
+	}
+
+	blocks := []*core.PostBlock{{Title: "hello"}}
+	filtered, err := processor.Evaluate(context.Background(), blocks)
+	if err != nil {
+		t.Fatalf("Evaluate error: %v", err)
+	}
+	if len(filtered) != 1 {
+		t.Fatalf("expected 1 filtered block, got %d", len(filtered))
+	}
+	if got := len(client.Calls); got != 1 {
+		t.Fatalf("expected 1 LLM call, got %d", got)
+	}
+	if blocks[0].Quality == nil || blocks[0].Quality.Result != "pass" {
+		t.Fatalf("expected block to pass quality, got: %#v", blocks[0].Quality)
+	}
+}

--- a/internal/processors/source/arxiv.go
+++ b/internal/processors/source/arxiv.go
@@ -88,6 +88,7 @@ func (p *ArxivProcessor) Fetch(ctx context.Context) ([]*core.PostBlock, error) {
 	if p.config.IncludeAbstractInChunks != nil {
 		includeAbstract = *p.config.IncludeAbstractInChunks
 	}
+	abstractOnly := p.config.AbstractOnly != nil && *p.config.AbstractOnly
 	chunking := defaultArxivChunkingConfig(p.config.Chunking)
 
 	blocks := make([]*core.PostBlock, 0, len(papers))
@@ -107,13 +108,22 @@ func (p *ArxivProcessor) Fetch(ctx context.Context) ([]*core.PostBlock, error) {
 		}
 
 		var chunks []core.ContentChunk
-		content, errors := p.fetchPaperContent(ctx, logger, paper)
-		if strings.TrimSpace(content) == "" {
+		var content string
+		var errors []core.ProcessError
+		if abstractOnly {
+			// Abstract-only mode ensures downstream processors receive only abstract text.
 			content = paper.Abstract
 			chunks = chunkArxivContent(content, paper.Abstract, false, chunking)
-			logger.Error("Failed to fetch full text content; using abstract only", "paper_id", paper.ID)
+			logger.Info("Using abstract-only mode for arXiv paper", "paper_id", paper.ID)
 		} else {
-			chunks = chunkArxivContent(content, paper.Abstract, includeAbstract, chunking)
+			content, errors = p.fetchPaperContent(ctx, logger, paper)
+			if strings.TrimSpace(content) == "" {
+				content = paper.Abstract
+				chunks = chunkArxivContent(content, paper.Abstract, false, chunking)
+				logger.Error("Failed to fetch full text content; using abstract only", "paper_id", paper.ID)
+			} else {
+				chunks = chunkArxivContent(content, paper.Abstract, includeAbstract, chunking)
+			}
 		}
 
 		block := &core.PostBlock{

--- a/internal/processors/source/arxiv.go
+++ b/internal/processors/source/arxiv.go
@@ -106,11 +106,15 @@ func (p *ArxivProcessor) Fetch(ctx context.Context) ([]*core.PostBlock, error) {
 			}
 		}
 
+		var chunks []core.ContentChunk
 		content, errors := p.fetchPaperContent(ctx, logger, paper)
 		if strings.TrimSpace(content) == "" {
 			content = paper.Abstract
+			chunks = chunkArxivContent(content, paper.Abstract, false, chunking)
+			logger.Error("Failed to fetch full text content; using abstract only", "paper_id", paper.ID)
+		} else {
+			chunks = chunkArxivContent(content, paper.Abstract, includeAbstract, chunking)
 		}
-		chunks := chunkArxivContent(content, paper.Abstract, includeAbstract, chunking)
 
 		block := &core.PostBlock{
 			ID:          paper.ID,

--- a/internal/processors/source/arxiv.go
+++ b/internal/processors/source/arxiv.go
@@ -143,10 +143,15 @@ func (p *ArxivProcessor) Fetch(ctx context.Context) ([]*core.PostBlock, error) {
 }
 
 func (p *ArxivProcessor) fetchPaperContent(ctx context.Context, logger *slog.Logger, paper arxiv.Paper) (string, []core.ProcessError) {
+	jinaReadOptions := jina.ReadOptions{
+		RetainImages: "none",
+		TokenBudget:  250000, // default to 250k tokens for arXiv papers
+	}
+
 	var errors []core.ProcessError
 	if paper.HTMLURL != "" {
 		logger.Info("Fetching arXiv HTML via Jina", "paper_id", paper.ID, "url", paper.HTMLURL)
-		if content, err := p.reader.Read(ctx, paper.HTMLURL, jina.ReadOptions{}); err == nil && strings.TrimSpace(content) != "" {
+		if content, err := p.reader.Read(ctx, paper.HTMLURL, jinaReadOptions); err == nil && strings.TrimSpace(content) != "" {
 			return content, nil
 		} else if err != nil {
 			logger.Info("arXiv HTML fetch failed, falling back to PDF", "paper_id", paper.ID, "error", err)
@@ -164,7 +169,7 @@ func (p *ArxivProcessor) fetchPaperContent(ctx context.Context, logger *slog.Log
 	}
 
 	logger.Info("Fetching arXiv PDF via Jina", "paper_id", paper.ID, "url", paper.PDFURL)
-	content, err := p.reader.Read(ctx, paper.PDFURL, jina.ReadOptions{})
+	content, err := p.reader.Read(ctx, paper.PDFURL, jinaReadOptions)
 	if err != nil || strings.TrimSpace(content) == "" {
 		msg := "arxiv pdf fetch failed"
 		if err != nil {

--- a/internal/processors/source/arxiv.go
+++ b/internal/processors/source/arxiv.go
@@ -1,0 +1,178 @@
+package source
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"strings"
+	"time"
+
+	"github.com/bakkerme/curator-ai/internal/config"
+	"github.com/bakkerme/curator-ai/internal/core"
+	"github.com/bakkerme/curator-ai/internal/dedupe"
+	"github.com/bakkerme/curator-ai/internal/sources/arxiv"
+	"github.com/bakkerme/curator-ai/internal/sources/jina"
+)
+
+// ArxivProcessor fetches papers from arXiv and emits PostBlocks with chunked content.
+type ArxivProcessor struct {
+	name    string
+	config  config.ArxivSource
+	fetcher arxiv.Fetcher
+	reader  jina.Reader
+	store   dedupe.SeenStore
+	logger  *slog.Logger
+}
+
+// NewArxivProcessor wires a new arXiv source processor.
+func NewArxivProcessor(cfg *config.ArxivSource, fetcher arxiv.Fetcher, reader jina.Reader, store dedupe.SeenStore, logger *slog.Logger) (*ArxivProcessor, error) {
+	if cfg == nil {
+		return nil, fmt.Errorf("arxiv config is required")
+	}
+	if logger == nil {
+		logger = slog.Default()
+	}
+	return &ArxivProcessor{
+		name:    "arxiv",
+		config:  *cfg,
+		fetcher: fetcher,
+		reader:  reader,
+		store:   store,
+		logger:  logger,
+	}, nil
+}
+
+func (p *ArxivProcessor) Name() string {
+	return p.name
+}
+
+func (p *ArxivProcessor) Configure(config map[string]interface{}) error {
+	return nil
+}
+
+func (p *ArxivProcessor) Validate() error {
+	if strings.TrimSpace(p.config.Query) == "" && len(p.config.Categories) == 0 {
+		return fmt.Errorf("arxiv query or categories are required")
+	}
+	if p.fetcher == nil {
+		return fmt.Errorf("arxiv fetcher is required")
+	}
+	if p.reader == nil {
+		return fmt.Errorf("jina reader is required")
+	}
+	return nil
+}
+
+func (p *ArxivProcessor) Fetch(ctx context.Context) ([]*core.PostBlock, error) {
+	if err := p.Validate(); err != nil {
+		return nil, err
+	}
+
+	logger := core.LoggerFromContext(ctx).With("stage", "source", "processor", p.name)
+	options := arxiv.SearchOptions{
+		Query:      p.config.Query,
+		Categories: p.config.Categories,
+		MaxResults: p.config.MaxResults,
+		SortBy:     p.config.SortBy,
+		SortOrder:  p.config.SortOrder,
+		DateFrom:   p.config.DateFrom,
+		DateTo:     p.config.DateTo,
+	}
+	logger.Info("Fetching papers from arXiv", "query", options.Query, "categories", options.Categories)
+	papers, err := p.fetcher.Search(ctx, options)
+	if err != nil {
+		return nil, err
+	}
+
+	includeAbstract := true
+	if p.config.IncludeAbstractInChunks != nil {
+		includeAbstract = *p.config.IncludeAbstractInChunks
+	}
+	chunking := defaultArxivChunkingConfig(p.config.Chunking)
+
+	blocks := make([]*core.PostBlock, 0, len(papers))
+	for _, paper := range papers {
+		if paper.ID == "" {
+			logger.Warn("Skipping arXiv paper without ID", "title", paper.Title)
+			continue
+		}
+		if p.store != nil {
+			seen, err := p.store.HasSeen(ctx, paper.ID)
+			if err != nil {
+				logger.Warn("Failed to check dedupe store", "paper_id", paper.ID, "error", err)
+			} else if seen {
+				logger.Info("Skipping already seen paper", "paper_id", paper.ID)
+				continue
+			}
+		}
+
+		content, errors := p.fetchPaperContent(ctx, logger, paper)
+		if strings.TrimSpace(content) == "" {
+			content = paper.Abstract
+		}
+		chunks := chunkArxivContent(content, paper.Abstract, includeAbstract, chunking)
+
+		block := &core.PostBlock{
+			ID:          paper.ID,
+			URL:         paper.AbsURL,
+			Title:       paper.Title,
+			Content:     content,
+			Author:      strings.Join(paper.Authors, ", "),
+			CreatedAt:   paper.PublishedAt,
+			SummaryPlan: summaryPlanFromConfig(p.config.SummaryPlan),
+			Chunks:      chunks,
+			ProcessedAt: time.Now().UTC(),
+		}
+		if len(errors) > 0 {
+			block.Errors = append(block.Errors, errors...)
+		}
+		blocks = append(blocks, block)
+
+		if p.store != nil {
+			if err := p.store.MarkSeen(ctx, paper.ID); err != nil {
+				logger.Warn("Failed to mark paper as seen", "paper_id", paper.ID, "error", err)
+			}
+		}
+	}
+
+	return blocks, nil
+}
+
+func (p *ArxivProcessor) fetchPaperContent(ctx context.Context, logger *slog.Logger, paper arxiv.Paper) (string, []core.ProcessError) {
+	var errors []core.ProcessError
+	if paper.HTMLURL != "" {
+		logger.Info("Fetching arXiv HTML via Jina", "paper_id", paper.ID, "url", paper.HTMLURL)
+		if content, err := p.reader.Read(ctx, paper.HTMLURL, jina.ReadOptions{}); err == nil && strings.TrimSpace(content) != "" {
+			return content, nil
+		} else if err != nil {
+			logger.Info("arXiv HTML fetch failed, falling back to PDF", "paper_id", paper.ID, "error", err)
+		}
+	}
+
+	if paper.PDFURL == "" {
+		errors = append(errors, core.ProcessError{
+			ProcessorName: p.name,
+			Stage:         "source",
+			Error:         "arxiv pdf url missing; unable to fetch full text",
+			OccurredAt:    time.Now().UTC(),
+		})
+		return "", errors
+	}
+
+	logger.Info("Fetching arXiv PDF via Jina", "paper_id", paper.ID, "url", paper.PDFURL)
+	content, err := p.reader.Read(ctx, paper.PDFURL, jina.ReadOptions{})
+	if err != nil || strings.TrimSpace(content) == "" {
+		msg := "arxiv pdf fetch failed"
+		if err != nil {
+			msg = fmt.Sprintf("arxiv pdf fetch failed: %v", err)
+		}
+		errors = append(errors, core.ProcessError{
+			ProcessorName: p.name,
+			Stage:         "source",
+			Error:         msg,
+			OccurredAt:    time.Now().UTC(),
+		})
+		return "", errors
+	}
+	return content, nil
+}

--- a/internal/processors/source/arxiv_chunk.go
+++ b/internal/processors/source/arxiv_chunk.go
@@ -1,0 +1,190 @@
+package source
+
+import (
+	"regexp"
+	"strings"
+
+	"github.com/bakkerme/curator-ai/internal/config"
+	"github.com/bakkerme/curator-ai/internal/core"
+)
+
+type arxivChunkingConfig struct {
+	mode             string
+	fallbackMaxChars int
+	minSectionChars  int
+}
+
+var (
+	sectionNumberPattern = regexp.MustCompile(`^\d+(\.\d+)*\s+\S+`)
+	knownSectionPattern  = regexp.MustCompile(`^(abstract|introduction|related work|method|methods|methodology|results|discussion|conclusion|limitations|references|appendix)\b`)
+)
+
+func defaultArxivChunkingConfig(cfg *config.ArxivChunkingConfig) arxivChunkingConfig {
+	if cfg == nil {
+		return arxivChunkingConfig{
+			mode:             "section",
+			fallbackMaxChars: 4000,
+			minSectionChars:  400,
+		}
+	}
+	chunking := arxivChunkingConfig{
+		mode:             strings.TrimSpace(cfg.Mode),
+		fallbackMaxChars: cfg.FallbackMaxChars,
+		minSectionChars:  cfg.MinSectionChars,
+	}
+	if chunking.mode == "" {
+		chunking.mode = "section"
+	}
+	if chunking.fallbackMaxChars <= 0 {
+		chunking.fallbackMaxChars = 4000
+	}
+	if chunking.minSectionChars <= 0 {
+		chunking.minSectionChars = 400
+	}
+	return chunking
+}
+
+func chunkArxivContent(content string, abstract string, includeAbstract bool, cfg arxivChunkingConfig) []core.ContentChunk {
+	content = strings.TrimSpace(content)
+	if content == "" && strings.TrimSpace(abstract) != "" {
+		return []core.ContentChunk{{Content: buildChunkText("", abstract, abstract, includeAbstract)}}
+	}
+	if strings.EqualFold(cfg.mode, "size") {
+		return chunkBySize(content, abstract, includeAbstract, cfg.fallbackMaxChars)
+	}
+	sections, headingsFound := splitSections(content)
+	if !headingsFound {
+		return chunkBySize(content, abstract, includeAbstract, cfg.fallbackMaxChars)
+	}
+	merged := mergeSmallSections(sections, cfg.minSectionChars)
+	chunks := make([]core.ContentChunk, 0, len(merged))
+	for _, section := range merged {
+		text := buildChunkText(section.title, section.content, abstract, includeAbstract)
+		chunks = append(chunks, core.ContentChunk{Content: text})
+	}
+	return chunks
+}
+
+type section struct {
+	title   string
+	content string
+}
+
+func splitSections(content string) ([]section, bool) {
+	lines := strings.Split(content, "\n")
+	var sections []section
+	current := section{}
+	var buffer []string
+	headingsFound := false
+
+	flush := func() {
+		if len(buffer) == 0 {
+			return
+		}
+		current.content = strings.TrimSpace(strings.Join(buffer, "\n"))
+		if strings.TrimSpace(current.content) != "" {
+			sections = append(sections, current)
+		}
+		buffer = nil
+	}
+
+	for _, line := range lines {
+		trimmed := strings.TrimSpace(line)
+		if isSectionHeading(trimmed) {
+			headingsFound = true
+			flush()
+			current = section{title: normalizeHeading(trimmed)}
+			continue
+		}
+		buffer = append(buffer, line)
+	}
+	flush()
+	return sections, headingsFound
+}
+
+func isSectionHeading(line string) bool {
+	if line == "" {
+		return false
+	}
+	if strings.HasPrefix(line, "#") {
+		heading := strings.TrimSpace(strings.TrimLeft(line, "#"))
+		return heading != ""
+	}
+	if sectionNumberPattern.MatchString(line) {
+		return true
+	}
+	if knownSectionPattern.MatchString(strings.ToLower(line)) {
+		if len(line) > 64 || strings.ContainsAny(line, ".:") {
+			return false
+		}
+		return true
+	}
+	return false
+}
+
+func normalizeHeading(line string) string {
+	if strings.HasPrefix(line, "#") {
+		return strings.TrimSpace(strings.TrimLeft(line, "#"))
+	}
+	return strings.TrimSpace(line)
+}
+
+func mergeSmallSections(sections []section, minChars int) []section {
+	if minChars <= 0 || len(sections) == 0 {
+		return sections
+	}
+	merged := make([]section, 0, len(sections))
+	var current *section
+	for _, sec := range sections {
+		if current == nil {
+			secCopy := sec
+			current = &secCopy
+			continue
+		}
+		if len(current.content) < minChars {
+			current.content = strings.TrimSpace(current.content + "\n\n" + sec.title + "\n" + sec.content)
+			continue
+		}
+		merged = append(merged, *current)
+		secCopy := sec
+		current = &secCopy
+	}
+	if current != nil {
+		merged = append(merged, *current)
+	}
+	return merged
+}
+
+func chunkBySize(content string, abstract string, includeAbstract bool, maxChars int) []core.ContentChunk {
+	if maxChars <= 0 {
+		maxChars = 4000
+	}
+	runes := []rune(content)
+	chunks := make([]core.ContentChunk, 0, (len(runes)+maxChars-1)/maxChars)
+	for start := 0; start < len(runes); start += maxChars {
+		end := start + maxChars
+		if end > len(runes) {
+			end = len(runes)
+		}
+		segment := string(runes[start:end])
+		text := buildChunkText("", segment, abstract, includeAbstract)
+		chunks = append(chunks, core.ContentChunk{Content: text})
+	}
+	return chunks
+}
+
+func buildChunkText(sectionTitle string, content string, abstract string, includeAbstract bool) string {
+	var builder strings.Builder
+	if includeAbstract && strings.TrimSpace(abstract) != "" {
+		builder.WriteString("Abstract:\n")
+		builder.WriteString(strings.TrimSpace(abstract))
+		builder.WriteString("\n\n")
+	}
+	if strings.TrimSpace(sectionTitle) != "" {
+		builder.WriteString("Section: ")
+		builder.WriteString(strings.TrimSpace(sectionTitle))
+		builder.WriteString("\n")
+	}
+	builder.WriteString(strings.TrimSpace(content))
+	return strings.TrimSpace(builder.String())
+}

--- a/internal/processors/source/arxiv_chunk.go
+++ b/internal/processors/source/arxiv_chunk.go
@@ -3,6 +3,7 @@ package source
 import (
 	"regexp"
 	"strings"
+	"unicode/utf8"
 
 	"github.com/bakkerme/curator-ai/internal/config"
 	"github.com/bakkerme/curator-ai/internal/core"
@@ -143,7 +144,8 @@ func mergeSmallSections(sections []section, minChars int) []section {
 			current = &secCopy
 			continue
 		}
-		if len(current.content) < minChars {
+		// Use rune count so thresholds are based on characters, not UTF-8 bytes.
+		if utf8.RuneCountInString(current.content) < minChars {
 			current.content = strings.TrimSpace(current.content + "\n\n" + sec.title + "\n" + sec.content)
 			continue
 		}

--- a/internal/processors/source/arxiv_chunk.go
+++ b/internal/processors/source/arxiv_chunk.go
@@ -47,7 +47,9 @@ func defaultArxivChunkingConfig(cfg *config.ArxivChunkingConfig) arxivChunkingCo
 func chunkArxivContent(content string, abstract string, includeAbstract bool, cfg arxivChunkingConfig) []core.ContentChunk {
 	content = strings.TrimSpace(content)
 	if content == "" && strings.TrimSpace(abstract) != "" {
-		return []core.ContentChunk{{Content: buildChunkText("", abstract, abstract, includeAbstract)}}
+		// When no full content is available, emit the abstract exactly once.
+		// We force includeAbstract=false here so abstract text is treated as primary content.
+		return []core.ContentChunk{{Content: buildChunkText("", abstract, abstract, false)}}
 	}
 	if strings.EqualFold(cfg.mode, "size") {
 		return chunkBySize(content, abstract, includeAbstract, cfg.fallbackMaxChars)

--- a/internal/processors/source/arxiv_chunk_test.go
+++ b/internal/processors/source/arxiv_chunk_test.go
@@ -1,0 +1,45 @@
+package source
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestChunkArxivContent_SplitsBySectionAndIncludesAbstract(t *testing.T) {
+	content := strings.Join([]string{
+		"# Introduction",
+		"Intro content.",
+		"",
+		"## Methods",
+		"Method content.",
+	}, "\n")
+
+	chunks := chunkArxivContent(content, "Abstract text.", true, arxivChunkingConfig{
+		mode:             "section",
+		fallbackMaxChars: 1000,
+		minSectionChars:  1,
+	})
+
+	if len(chunks) != 2 {
+		t.Fatalf("expected 2 chunks, got %d", len(chunks))
+	}
+	if !strings.Contains(chunks[0].Content, "Abstract text.") {
+		t.Fatalf("expected abstract context in first chunk")
+	}
+	if !strings.Contains(chunks[0].Content, "Section: Introduction") {
+		t.Fatalf("expected section title in first chunk")
+	}
+}
+
+func TestChunkArxivContent_FallbacksToSizeChunking(t *testing.T) {
+	content := "no headings here"
+	chunks := chunkArxivContent(content, "", false, arxivChunkingConfig{
+		mode:             "section",
+		fallbackMaxChars: 5,
+		minSectionChars:  1,
+	})
+
+	if len(chunks) < 2 {
+		t.Fatalf("expected multiple chunks, got %d", len(chunks))
+	}
+}

--- a/internal/processors/source/arxiv_chunk_test.go
+++ b/internal/processors/source/arxiv_chunk_test.go
@@ -43,3 +43,33 @@ func TestChunkArxivContent_FallbacksToSizeChunking(t *testing.T) {
 		t.Fatalf("expected multiple chunks, got %d", len(chunks))
 	}
 }
+
+func TestChunkArxivContent_EmptyContentAbstractPresent_NoDupWhenIncludeAbstractTrue(t *testing.T) {
+	chunks := chunkArxivContent("", "Abstract text.", true, arxivChunkingConfig{
+		mode:             "section",
+		fallbackMaxChars: 1000,
+		minSectionChars:  1,
+	})
+
+	if len(chunks) != 1 {
+		t.Fatalf("expected 1 chunk, got %d", len(chunks))
+	}
+	if chunks[0].Content != "Abstract text." {
+		t.Fatalf("expected abstract once, got %q", chunks[0].Content)
+	}
+}
+
+func TestChunkArxivContent_EmptyContentAbstractPresent_IncludeAbstractFalseStillReturnsAbstract(t *testing.T) {
+	chunks := chunkArxivContent("", "Abstract text.", false, arxivChunkingConfig{
+		mode:             "section",
+		fallbackMaxChars: 1000,
+		minSectionChars:  1,
+	})
+
+	if len(chunks) != 1 {
+		t.Fatalf("expected 1 chunk, got %d", len(chunks))
+	}
+	if chunks[0].Content != "Abstract text." {
+		t.Fatalf("expected abstract content, got %q", chunks[0].Content)
+	}
+}

--- a/internal/processors/source/arxiv_chunk_test.go
+++ b/internal/processors/source/arxiv_chunk_test.go
@@ -73,3 +73,18 @@ func TestChunkArxivContent_EmptyContentAbstractPresent_IncludeAbstractFalseStill
 		t.Fatalf("expected abstract content, got %q", chunks[0].Content)
 	}
 }
+
+func TestMergeSmallSections_UsesRuneCountForUTF8Threshold(t *testing.T) {
+	sections := []section{
+		{title: "Intro", content: "你你"},
+		{title: "Method", content: "method body"},
+	}
+
+	merged := mergeSmallSections(sections, 3)
+	if len(merged) != 1 {
+		t.Fatalf("expected 1 merged section when first section has 2 runes (<3), got %d", len(merged))
+	}
+	if !strings.Contains(merged[0].content, "Method") {
+		t.Fatalf("expected merged content to include next section title, got %q", merged[0].content)
+	}
+}

--- a/internal/processors/source/arxiv_test.go
+++ b/internal/processors/source/arxiv_test.go
@@ -1,0 +1,122 @@
+package source
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/bakkerme/curator-ai/internal/config"
+	"github.com/bakkerme/curator-ai/internal/core"
+	"github.com/bakkerme/curator-ai/internal/sources/arxiv"
+	"github.com/bakkerme/curator-ai/internal/sources/jina"
+)
+
+type arxivFetcherMock struct {
+	papers []arxiv.Paper
+}
+
+func (m *arxivFetcherMock) Search(ctx context.Context, options arxiv.SearchOptions) ([]arxiv.Paper, error) {
+	_ = ctx
+	_ = options
+	return m.papers, nil
+}
+
+type arxivReaderMock struct {
+	pages map[string]string
+	calls []string
+}
+
+func (m *arxivReaderMock) Read(ctx context.Context, url string, options jina.ReadOptions) (string, error) {
+	_ = ctx
+	_ = options
+	m.calls = append(m.calls, url)
+	return m.pages[url], nil
+}
+
+func TestArxivProcessor_AbstractOnlyUsesAbstractContent(t *testing.T) {
+	abstractOnly := true
+	cfg := &config.ArxivSource{
+		Query:        "llm security",
+		AbstractOnly: &abstractOnly,
+		SummaryPlan:  &config.SummaryPlanConfig{Mode: core.SummaryModeFull},
+	}
+	fetcher := &arxivFetcherMock{
+		papers: []arxiv.Paper{{
+			ID:          "1234.5678",
+			Title:       "Paper",
+			Abstract:    "This is only the abstract.",
+			Authors:     []string{"A", "B"},
+			PublishedAt: time.Now().UTC(),
+			AbsURL:      "https://arxiv.org/abs/1234.5678",
+			HTMLURL:     "https://arxiv.org/html/1234.5678",
+			PDFURL:      "https://arxiv.org/pdf/1234.5678",
+		}},
+	}
+	reader := &arxivReaderMock{
+		pages: map[string]string{
+			"https://arxiv.org/html/1234.5678": "full paper content",
+		},
+	}
+
+	processor, err := NewArxivProcessor(cfg, fetcher, reader, nil, nil)
+	if err != nil {
+		t.Fatalf("failed to create processor: %v", err)
+	}
+
+	blocks, err := processor.Fetch(context.Background())
+	if err != nil {
+		t.Fatalf("fetch failed: %v", err)
+	}
+	if len(blocks) != 1 {
+		t.Fatalf("expected 1 block, got %d", len(blocks))
+	}
+	if blocks[0].Content != "This is only the abstract." {
+		t.Fatalf("expected abstract-only content, got %q", blocks[0].Content)
+	}
+	if len(reader.calls) != 0 {
+		t.Fatalf("expected no Jina fetches in abstract_only mode, got %d calls", len(reader.calls))
+	}
+}
+
+func TestArxivProcessor_DefaultModeFetchesFullText(t *testing.T) {
+	cfg := &config.ArxivSource{
+		Query:       "llm security",
+		SummaryPlan: &config.SummaryPlanConfig{Mode: core.SummaryModeFull},
+	}
+	fetcher := &arxivFetcherMock{
+		papers: []arxiv.Paper{{
+			ID:          "1234.5678",
+			Title:       "Paper",
+			Abstract:    "short abstract",
+			Authors:     []string{"A"},
+			PublishedAt: time.Now().UTC(),
+			AbsURL:      "https://arxiv.org/abs/1234.5678",
+			HTMLURL:     "https://arxiv.org/html/1234.5678",
+		}},
+	}
+	reader := &arxivReaderMock{
+		pages: map[string]string{
+			"https://arxiv.org/html/1234.5678": "full paper content",
+		},
+	}
+
+	processor, err := NewArxivProcessor(cfg, fetcher, reader, nil, nil)
+	if err != nil {
+		t.Fatalf("failed to create processor: %v", err)
+	}
+
+	blocks, err := processor.Fetch(context.Background())
+	if err != nil {
+		t.Fatalf("fetch failed: %v", err)
+	}
+	if len(blocks) != 1 {
+		t.Fatalf("expected 1 block, got %d", len(blocks))
+	}
+	if blocks[0].Content != "full paper content" {
+		t.Fatalf("expected full text content, got %q", blocks[0].Content)
+	}
+	if len(reader.calls) != 1 {
+		t.Fatalf("expected 1 Jina fetch in default mode, got %d calls", len(reader.calls))
+	}
+}
+

--- a/internal/processors/summary/llm.go
+++ b/internal/processors/summary/llm.go
@@ -148,6 +148,7 @@ func (p *PostLLMProcessor) Summarize(ctx context.Context, blocks []*core.PostBlo
 					return err
 				}
 				block.Chunks[i].Summary = response.Content
+				logger.Info("llm post summary chunk summarized", "block_id", block.ID, "chunk_index", i, "chunk_length", len(chunk.Content))
 			}
 			return nil
 		}

--- a/internal/retry/retry.go
+++ b/internal/retry/retry.go
@@ -2,6 +2,7 @@ package retry
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"math/rand"
 	"time"
@@ -12,6 +13,33 @@ type Config struct {
 	BaseDelay time.Duration
 	MaxDelay  time.Duration
 	Jitter    time.Duration
+}
+
+// permanentError marks an error as non-retryable for retry.Do.
+type permanentError struct {
+	err error
+}
+
+func (e permanentError) Error() string {
+	return e.err.Error()
+}
+
+func (e permanentError) Unwrap() error {
+	return e.err
+}
+
+// Permanent wraps an error to signal retry.Do to stop retrying immediately.
+func Permanent(err error) error {
+	if err == nil {
+		return nil
+	}
+	return permanentError{err: err}
+}
+
+// IsPermanent reports whether an error was marked as non-retryable.
+func IsPermanent(err error) bool {
+	var p permanentError
+	return err != nil && errors.As(err, &p)
 }
 
 func Do(ctx context.Context, config Config, fn func() error) error {
@@ -36,6 +64,9 @@ func Do(ctx context.Context, config Config, fn func() error) error {
 	delay := baseDelay
 	for attempt := 0; attempt < attempts; attempt++ {
 		if err := fn(); err != nil {
+			if IsPermanent(err) {
+				return err
+			}
 			lastErr = err
 			if attempt == attempts-1 {
 				break

--- a/internal/runner/factory/factory.go
+++ b/internal/runner/factory/factory.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"log/slog"
 	"strings"
-	"time"
 
 	"github.com/bakkerme/curator-ai/internal/config"
 	"github.com/bakkerme/curator-ai/internal/core"
@@ -54,7 +53,7 @@ func NewFromEnvConfig(logger *slog.Logger, env config.EnvConfig) *Factory {
 		DefaultTemperature: env.OpenAI.Temperature,
 		SMTPDefaults:       env.SMTP,
 		JinaReader:         jinaimpl.NewReader(env.Jina.HTTPTimeout, env.Jina.UserAgent, env.Jina.BaseURL, env.Jina.APIKey),
-		ArxivFetcher:       arxivimpl.NewFetcher(10*time.Second, "curator-ai/0.1", ""),
+		ArxivFetcher:       arxivimpl.NewFetcher(env.Arxiv.HTTPTimeout, env.Arxiv.UserAgent, env.Arxiv.BaseURL),
 		RedditFetcher:      reddit.NewFetcher(logger, env.Reddit.HTTPTimeout, env.Reddit.UserAgent, env.Reddit.ClientID, env.Reddit.ClientSecret, env.Reddit.Username, env.Reddit.Password),
 		RSSFetcher:         rssimpl.NewFetcher(env.RSS.HTTPTimeout, env.RSS.UserAgent),
 		// Leave EmailSender nil so the output processor can build it from the merged

--- a/internal/runner/factory/factory.go
+++ b/internal/runner/factory/factory.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"log/slog"
 	"strings"
+	"time"
 
 	"github.com/bakkerme/curator-ai/internal/config"
 	"github.com/bakkerme/curator-ai/internal/core"
@@ -18,6 +19,8 @@ import (
 	"github.com/bakkerme/curator-ai/internal/processors/summary"
 	"github.com/bakkerme/curator-ai/internal/processors/trigger"
 	"github.com/bakkerme/curator-ai/internal/runner/snapshot"
+	"github.com/bakkerme/curator-ai/internal/sources/arxiv"
+	arxivimpl "github.com/bakkerme/curator-ai/internal/sources/arxiv/impl"
 	"github.com/bakkerme/curator-ai/internal/sources/jina"
 	jinaimpl "github.com/bakkerme/curator-ai/internal/sources/jina/impl"
 	"github.com/bakkerme/curator-ai/internal/sources/reddit"
@@ -32,6 +35,7 @@ type Factory struct {
 	DefaultTemperature *float64
 	SMTPDefaults       config.SMTPEnvConfig
 	JinaReader         jina.Reader
+	ArxivFetcher       arxiv.Fetcher
 	RedditFetcher      reddit.Fetcher
 	RSSFetcher         rss.Fetcher
 	EmailSender        email.Sender
@@ -50,6 +54,7 @@ func NewFromEnvConfig(logger *slog.Logger, env config.EnvConfig) *Factory {
 		DefaultTemperature: env.OpenAI.Temperature,
 		SMTPDefaults:       env.SMTP,
 		JinaReader:         jinaimpl.NewReader(env.Jina.HTTPTimeout, env.Jina.UserAgent, env.Jina.BaseURL, env.Jina.APIKey),
+		ArxivFetcher:       arxivimpl.NewFetcher(10*time.Second, "curator-ai/0.1", ""),
 		RedditFetcher:      reddit.NewFetcher(logger, env.Reddit.HTTPTimeout, env.Reddit.UserAgent, env.Reddit.ClientID, env.Reddit.ClientSecret, env.Reddit.Username, env.Reddit.Password),
 		RSSFetcher:         rssimpl.NewFetcher(env.RSS.HTTPTimeout, env.RSS.UserAgent),
 		// Leave EmailSender nil so the output processor can build it from the merged
@@ -73,6 +78,14 @@ func (f *Factory) NewRedditSource(cfg *config.RedditSource) (core.SourceProcesso
 
 func (f *Factory) NewRSSSource(cfg *config.RSSSource) (core.SourceProcessor, error) {
 	processor, err := source.NewRSSProcessor(cfg, f.RSSFetcher, f.SeenStore)
+	if err != nil {
+		return nil, err
+	}
+	return snapshot.WrapSource(processor, cfg.Snapshot), nil
+}
+
+func (f *Factory) NewArxivSource(cfg *config.ArxivSource) (core.SourceProcessor, error) {
+	processor, err := source.NewArxivProcessor(cfg, f.ArxivFetcher, f.JinaReader, f.SeenStore, f.Logger)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/sources/arxiv/arxiv.go
+++ b/internal/sources/arxiv/arxiv.go
@@ -1,0 +1,36 @@
+package arxiv
+
+import (
+	"context"
+	"time"
+)
+
+// SearchOptions defines filters for arXiv API queries.
+type SearchOptions struct {
+	Query      string
+	Categories []string
+	MaxResults int
+	SortBy     string
+	SortOrder  string
+	DateFrom   string
+	DateTo     string
+}
+
+// Paper represents a normalized arXiv API response entry.
+type Paper struct {
+	ID          string
+	Title       string
+	Abstract    string
+	Authors     []string
+	Categories  []string
+	PublishedAt time.Time
+	UpdatedAt   time.Time
+	AbsURL      string
+	PDFURL      string
+	HTMLURL     string
+}
+
+// Fetcher retrieves papers from the arXiv API.
+type Fetcher interface {
+	Search(ctx context.Context, options SearchOptions) ([]Paper, error)
+}

--- a/internal/sources/arxiv/impl/fetcher.go
+++ b/internal/sources/arxiv/impl/fetcher.go
@@ -1,0 +1,296 @@
+package impl
+
+import (
+	"context"
+	"encoding/xml"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+
+	"github.com/bakkerme/curator-ai/internal/retry"
+	"github.com/bakkerme/curator-ai/internal/sources/arxiv"
+)
+
+const defaultBaseURL = "https://export.arxiv.org/api/query"
+
+// Fetcher implements the arXiv API client for Atom-based responses.
+type Fetcher struct {
+	client    *http.Client
+	baseURL   string
+	userAgent string
+}
+
+// NewFetcher constructs an arXiv API client with timeout and user agent controls.
+func NewFetcher(timeout time.Duration, userAgent string, baseURL string) *Fetcher {
+	if strings.TrimSpace(baseURL) == "" {
+		baseURL = defaultBaseURL
+	}
+	if strings.TrimSpace(userAgent) == "" {
+		userAgent = "curator-ai/0.1"
+	}
+	return &Fetcher{
+		client:    &http.Client{Timeout: timeout},
+		baseURL:   baseURL,
+		userAgent: userAgent,
+	}
+}
+
+// Search queries arXiv and returns normalized papers based on the provided options.
+func (f *Fetcher) Search(ctx context.Context, options arxiv.SearchOptions) ([]arxiv.Paper, error) {
+	query, err := buildSearchQuery(options)
+	if err != nil {
+		return nil, err
+	}
+	u, err := url.Parse(f.baseURL)
+	if err != nil {
+		return nil, fmt.Errorf("parse arxiv base url: %w", err)
+	}
+	values := u.Query()
+	values.Set("search_query", query)
+	if options.MaxResults > 0 {
+		values.Set("max_results", fmt.Sprintf("%d", options.MaxResults))
+	}
+	if strings.TrimSpace(options.SortBy) != "" {
+		values.Set("sortBy", strings.TrimSpace(options.SortBy))
+	}
+	if strings.TrimSpace(options.SortOrder) != "" {
+		values.Set("sortOrder", strings.TrimSpace(options.SortOrder))
+	}
+	u.RawQuery = values.Encode()
+
+	var payload []byte
+	err = retry.Do(ctx, retry.Config{Attempts: 3, BaseDelay: 200 * time.Millisecond}, func() error {
+		req, err := http.NewRequestWithContext(ctx, http.MethodGet, u.String(), nil)
+		if err != nil {
+			return err
+		}
+		req.Header.Set("User-Agent", f.userAgent)
+		resp, err := f.client.Do(req)
+		if err != nil {
+			return err
+		}
+		defer resp.Body.Close()
+		if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+			return fmt.Errorf("arxiv api status %d", resp.StatusCode)
+		}
+		body, err := io.ReadAll(resp.Body)
+		if err != nil {
+			return err
+		}
+		payload = body
+		return nil
+	})
+	if err != nil {
+		return nil, fmt.Errorf("arxiv api request failed: %w", err)
+	}
+
+	entries, err := parseFeed(payload)
+	if err != nil {
+		return nil, err
+	}
+
+	papers := make([]arxiv.Paper, 0, len(entries))
+	for _, entry := range entries {
+		paper := entry.toPaper()
+		papers = append(papers, paper)
+	}
+	return papers, nil
+}
+
+func buildSearchQuery(options arxiv.SearchOptions) (string, error) {
+	var clauses []string
+	if strings.TrimSpace(options.Query) != "" {
+		clauses = append(clauses, fmt.Sprintf("all:%q", strings.TrimSpace(options.Query)))
+	}
+	if len(options.Categories) > 0 {
+		parts := make([]string, 0, len(options.Categories))
+		for _, cat := range options.Categories {
+			cat = strings.TrimSpace(cat)
+			if cat == "" {
+				continue
+			}
+			parts = append(parts, fmt.Sprintf("cat:%s", cat))
+		}
+		if len(parts) > 0 {
+			clauses = append(clauses, "("+strings.Join(parts, " OR ")+")")
+		}
+	}
+	if dateClause := buildDateClause(options.DateFrom, options.DateTo); dateClause != "" {
+		clauses = append(clauses, dateClause)
+	}
+	if len(clauses) == 0 {
+		return "", fmt.Errorf("arxiv search requires query or categories")
+	}
+	return strings.Join(clauses, " AND "), nil
+}
+
+func buildDateClause(dateFrom string, dateTo string) string {
+	from, fromOK := formatDateRange(dateFrom, false)
+	to, toOK := formatDateRange(dateTo, true)
+	if !fromOK && !toOK {
+		return ""
+	}
+	if !fromOK {
+		from = "*"
+	}
+	if !toOK {
+		to = "*"
+	}
+	return fmt.Sprintf("submittedDate:[%s TO %s]", from, to)
+}
+
+func formatDateRange(input string, endOfDay bool) (string, bool) {
+	input = strings.TrimSpace(input)
+	if input == "" {
+		return "", false
+	}
+	layouts := []string{"2006-01-02", "20060102"}
+	var parsed time.Time
+	var err error
+	for _, layout := range layouts {
+		parsed, err = time.Parse(layout, input)
+		if err == nil {
+			break
+		}
+	}
+	if err != nil {
+		return "", false
+	}
+	if endOfDay {
+		parsed = parsed.Add(23*time.Hour + 59*time.Minute)
+	}
+	return parsed.UTC().Format("200601021504"), true
+}
+
+type feed struct {
+	Entries []entry `xml:"entry"`
+}
+
+type entry struct {
+	ID         string     `xml:"id"`
+	Title      string     `xml:"title"`
+	Summary    string     `xml:"summary"`
+	Updated    string     `xml:"updated"`
+	Published  string     `xml:"published"`
+	Authors    []author   `xml:"author"`
+	Categories []category `xml:"category"`
+	Links      []link     `xml:"link"`
+}
+
+type author struct {
+	Name string `xml:"name"`
+}
+
+type category struct {
+	Term string `xml:"term,attr"`
+}
+
+type link struct {
+	Href string `xml:"href,attr"`
+	Rel  string `xml:"rel,attr"`
+	Type string `xml:"type,attr"`
+}
+
+func parseFeed(payload []byte) ([]entry, error) {
+	var parsed feed
+	if err := xml.Unmarshal(payload, &parsed); err != nil {
+		return nil, fmt.Errorf("parse arxiv feed: %w", err)
+	}
+	return parsed.Entries, nil
+}
+
+func (e entry) toPaper() arxiv.Paper {
+	title := strings.TrimSpace(e.Title)
+	abstract := strings.TrimSpace(e.Summary)
+	rawID := strings.TrimSpace(e.ID)
+	absURL := normalizeAbsURL(rawID)
+	id := normalizeArxivID(rawID)
+
+	publishedAt := parseTime(e.Published)
+	updatedAt := parseTime(e.Updated)
+
+	authors := make([]string, 0, len(e.Authors))
+	for _, a := range e.Authors {
+		name := strings.TrimSpace(a.Name)
+		if name != "" {
+			authors = append(authors, name)
+		}
+	}
+	categories := make([]string, 0, len(e.Categories))
+	for _, c := range e.Categories {
+		term := strings.TrimSpace(c.Term)
+		if term != "" {
+			categories = append(categories, term)
+		}
+	}
+
+	pdfURL := findPDFURL(e.Links)
+	if pdfURL == "" && absURL != "" {
+		pdfURL = strings.Replace(absURL, "/abs/", "/pdf/", 1) + ".pdf"
+	}
+
+	htmlURL := ""
+	if id != "" {
+		htmlURL = "https://arxiv.org/html/" + id
+	}
+
+	return arxiv.Paper{
+		ID:          id,
+		Title:       title,
+		Abstract:    abstract,
+		Authors:     authors,
+		Categories:  categories,
+		PublishedAt: publishedAt,
+		UpdatedAt:   updatedAt,
+		AbsURL:      absURL,
+		PDFURL:      pdfURL,
+		HTMLURL:     htmlURL,
+	}
+}
+
+func parseTime(value string) time.Time {
+	parsed, err := time.Parse(time.RFC3339, strings.TrimSpace(value))
+	if err != nil {
+		return time.Time{}
+	}
+	return parsed
+}
+
+func normalizeAbsURL(raw string) string {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return ""
+	}
+	if strings.Contains(raw, "/abs/") {
+		return raw
+	}
+	return strings.TrimSuffix(raw, "/") + "/abs"
+}
+
+func normalizeArxivID(raw string) string {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return ""
+	}
+	parts := strings.Split(raw, "/")
+	id := parts[len(parts)-1]
+	if strings.Contains(id, "v") {
+		versionIndex := strings.LastIndex(id, "v")
+		if versionIndex > 0 {
+			return id[:versionIndex]
+		}
+	}
+	return id
+}
+
+func findPDFURL(links []link) string {
+	for _, l := range links {
+		if strings.EqualFold(l.Type, "application/pdf") && strings.TrimSpace(l.Href) != "" {
+			return strings.TrimSpace(l.Href)
+		}
+	}
+	return ""
+}

--- a/internal/sources/arxiv/impl/fetcher.go
+++ b/internal/sources/arxiv/impl/fetcher.go
@@ -275,15 +275,49 @@ func normalizeArxivID(raw string) string {
 	if raw == "" {
 		return ""
 	}
-	parts := strings.Split(raw, "/")
-	id := parts[len(parts)-1]
-	if strings.Contains(id, "v") {
-		versionIndex := strings.LastIndex(id, "v")
-		if versionIndex > 0 {
-			return id[:versionIndex]
+
+	// IDs are commonly provided as full URLs (`.../abs/<id>`) but may also be bare
+	// IDs. Legacy IDs have an archive prefix (`hep-th/9901001v2`) that must be
+	// preserved for stable dedupe keys.
+	id := raw
+	hadAbsPrefix := false
+	if _, after, ok := strings.Cut(raw, "/abs/"); ok {
+		id = after
+		hadAbsPrefix = true
+	}
+
+	id = strings.Trim(id, "/")
+	if idx := strings.IndexAny(id, "?#"); idx >= 0 {
+		id = id[:idx]
+	}
+	if id == "" {
+		return ""
+	}
+
+	if strings.Contains(id, "/") {
+		parts := strings.Split(id, "/")
+		if hadAbsPrefix || strings.Count(id, "/") == 1 {
+			// Preserve legacy archive-prefixed IDs (for example, `hep-th/9901001v2`).
+			id = strings.TrimSpace(parts[len(parts)-2]) + "/" + strings.TrimSpace(parts[len(parts)-1])
+		} else {
+			id = strings.TrimSpace(parts[len(parts)-1])
 		}
 	}
-	return id
+
+	return stripArxivVersionSuffix(id)
+}
+
+func stripArxivVersionSuffix(id string) string {
+	versionIndex := strings.LastIndexAny(id, "vV")
+	if versionIndex <= 0 || versionIndex == len(id)-1 {
+		return id
+	}
+	for _, r := range id[versionIndex+1:] {
+		if r < '0' || r > '9' {
+			return id
+		}
+	}
+	return id[:versionIndex]
 }
 
 func findPDFURL(links []link) string {

--- a/internal/sources/arxiv/impl/fetcher.go
+++ b/internal/sources/arxiv/impl/fetcher.go
@@ -74,7 +74,12 @@ func (f *Fetcher) Search(ctx context.Context, options arxiv.SearchOptions) ([]ar
 		}
 		defer resp.Body.Close()
 		if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-			return fmt.Errorf("arxiv api status %d", resp.StatusCode)
+			bodySnippet := readBodySnippet(resp.Body, 2048)
+			statusErr := fmt.Errorf("arxiv api status %d: %s", resp.StatusCode, bodySnippet)
+			if shouldRetryStatus(resp.StatusCode) {
+				return statusErr
+			}
+			return retry.Permanent(statusErr)
 		}
 		body, err := io.ReadAll(resp.Body)
 		if err != nil {
@@ -327,4 +332,23 @@ func findPDFURL(links []link) string {
 		}
 	}
 	return ""
+}
+
+func shouldRetryStatus(statusCode int) bool {
+	return statusCode == http.StatusTooManyRequests || statusCode >= 500
+}
+
+func readBodySnippet(body io.Reader, limit int64) string {
+	if limit <= 0 {
+		limit = 2048
+	}
+	payload, err := io.ReadAll(io.LimitReader(body, limit))
+	if err != nil {
+		return "failed to read response body"
+	}
+	snippet := strings.TrimSpace(string(payload))
+	if snippet == "" {
+		return "empty response body"
+	}
+	return snippet
 }

--- a/internal/sources/arxiv/impl/fetcher.go
+++ b/internal/sources/arxiv/impl/fetcher.go
@@ -265,14 +265,11 @@ func parseTime(value string) time.Time {
 }
 
 func normalizeAbsURL(raw string) string {
-	raw = strings.TrimSpace(raw)
-	if raw == "" {
+	id := normalizeArxivID(raw)
+	if id == "" {
 		return ""
 	}
-	if strings.Contains(raw, "/abs/") {
-		return raw
-	}
-	return strings.TrimSuffix(raw, "/") + "/abs"
+	return "https://arxiv.org/abs/" + id
 }
 
 func normalizeArxivID(raw string) string {
@@ -281,35 +278,61 @@ func normalizeArxivID(raw string) string {
 		return ""
 	}
 
-	// IDs are commonly provided as full URLs (`.../abs/<id>`) but may also be bare
-	// IDs. Legacy IDs have an archive prefix (`hep-th/9901001v2`) that must be
-	// preserved for stable dedupe keys.
+	id, hadCanonicalPrefix := extractArxivIdentifier(raw)
+	if id == "" {
+		return ""
+	}
+
+	// Legacy IDs may contain one slash (archive/id). If we extracted from canonical
+	// arXiv URL paths, preserve the trailing archive/id pair.
+	if strings.Contains(id, "/") {
+		parts := strings.Split(id, "/")
+		filtered := make([]string, 0, len(parts))
+		for _, part := range parts {
+			part = strings.TrimSpace(part)
+			if part != "" {
+				filtered = append(filtered, part)
+			}
+		}
+		if len(filtered) == 0 {
+			return ""
+		}
+		if (hadCanonicalPrefix || len(filtered) == 2) && len(filtered) >= 2 {
+			id = filtered[len(filtered)-2] + "/" + filtered[len(filtered)-1]
+		} else {
+			id = filtered[len(filtered)-1]
+		}
+	}
+
+	return stripArxivVersionSuffix(id)
+}
+
+func extractArxivIdentifier(raw string) (string, bool) {
 	id := raw
-	hadAbsPrefix := false
+	hadCanonicalPrefix := false
 	if _, after, ok := strings.Cut(raw, "/abs/"); ok {
 		id = after
-		hadAbsPrefix = true
+		hadCanonicalPrefix = true
+	} else if strings.HasPrefix(raw, "abs/") {
+		id = strings.TrimPrefix(raw, "abs/")
+		hadCanonicalPrefix = true
+	} else if _, after, ok := strings.Cut(raw, "/pdf/"); ok {
+		id = after
+		hadCanonicalPrefix = true
+	} else if strings.HasPrefix(raw, "pdf/") {
+		id = strings.TrimPrefix(raw, "pdf/")
+		hadCanonicalPrefix = true
 	}
 
 	id = strings.Trim(id, "/")
 	if idx := strings.IndexAny(id, "?#"); idx >= 0 {
 		id = id[:idx]
 	}
-	if id == "" {
-		return ""
+	if strings.HasSuffix(strings.ToLower(id), ".pdf") {
+		id = id[:len(id)-4]
 	}
-
-	if strings.Contains(id, "/") {
-		parts := strings.Split(id, "/")
-		if hadAbsPrefix || strings.Count(id, "/") == 1 {
-			// Preserve legacy archive-prefixed IDs (for example, `hep-th/9901001v2`).
-			id = strings.TrimSpace(parts[len(parts)-2]) + "/" + strings.TrimSpace(parts[len(parts)-1])
-		} else {
-			id = strings.TrimSpace(parts[len(parts)-1])
-		}
-	}
-
-	return stripArxivVersionSuffix(id)
+	id = strings.TrimSpace(strings.Trim(id, "/"))
+	return id, hadCanonicalPrefix
 }
 
 func stripArxivVersionSuffix(id string) string {

--- a/internal/sources/arxiv/impl/fetcher_test.go
+++ b/internal/sources/arxiv/impl/fetcher_test.go
@@ -1,8 +1,13 @@
 package impl
 
 import (
+	"context"
+	"net/http"
+	"net/http/httptest"
 	"strings"
+	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/bakkerme/curator-ai/internal/sources/arxiv"
 )
@@ -134,6 +139,75 @@ func TestNormalizeArxivID(t *testing.T) {
 				t.Fatalf("normalizeArxivID(%q): got %q, want %q", tc.raw, got, tc.want)
 			}
 		})
+	}
+}
+
+func TestSearch_DoesNotRetryPermanent4xx(t *testing.T) {
+	var calls int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt32(&calls, 1)
+		w.WriteHeader(http.StatusBadRequest)
+		_, _ = w.Write([]byte("bad query syntax"))
+	}))
+	defer server.Close()
+
+	fetcher := NewFetcher(2*time.Second, "test-agent", server.URL)
+	_, err := fetcher.Search(context.Background(), searchOptions("bad", nil, "", ""))
+	if err == nil {
+		t.Fatalf("expected search error")
+	}
+	if got := atomic.LoadInt32(&calls); got != 1 {
+		t.Fatalf("expected one request without retries, got %d", got)
+	}
+	if !strings.Contains(err.Error(), "status 400") {
+		t.Fatalf("expected status code in error, got %v", err)
+	}
+	if !strings.Contains(err.Error(), "bad query syntax") {
+		t.Fatalf("expected response body details in error, got %v", err)
+	}
+}
+
+func TestSearch_RetriesTransientStatuses(t *testing.T) {
+	var calls int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		call := atomic.AddInt32(&calls, 1)
+		if call < 3 {
+			if call == 1 {
+				w.WriteHeader(http.StatusTooManyRequests)
+				_, _ = w.Write([]byte("rate limited"))
+				return
+			}
+			w.WriteHeader(http.StatusBadGateway)
+			_, _ = w.Write([]byte("upstream failure"))
+			return
+		}
+
+		w.Header().Set("Content-Type", "application/atom+xml")
+		_, _ = w.Write([]byte(`<?xml version="1.0" encoding="UTF-8"?>
+<feed xmlns="http://www.w3.org/2005/Atom">
+  <entry>
+    <id>http://arxiv.org/abs/1234.5678v1</id>
+    <title>Sample Paper</title>
+    <summary>Abstract text.</summary>
+    <published>2024-01-10T00:00:00Z</published>
+    <updated>2024-01-12T00:00:00Z</updated>
+    <author><name>Jane Doe</name></author>
+    <category term="cs.CL"/>
+  </entry>
+</feed>`))
+	}))
+	defer server.Close()
+
+	fetcher := NewFetcher(2*time.Second, "test-agent", server.URL)
+	papers, err := fetcher.Search(context.Background(), searchOptions("test", nil, "", ""))
+	if err != nil {
+		t.Fatalf("expected search to succeed after retries, got %v", err)
+	}
+	if got := atomic.LoadInt32(&calls); got != 3 {
+		t.Fatalf("expected 3 calls (2 retries + success), got %d", got)
+	}
+	if len(papers) != 1 {
+		t.Fatalf("expected one paper, got %d", len(papers))
 	}
 }
 

--- a/internal/sources/arxiv/impl/fetcher_test.go
+++ b/internal/sources/arxiv/impl/fetcher_test.go
@@ -58,6 +58,85 @@ func TestParseFeed(t *testing.T) {
 	}
 }
 
+func TestParseFeedLegacyID(t *testing.T) {
+	payload := []byte(`<?xml version="1.0" encoding="UTF-8"?>
+<feed xmlns="http://www.w3.org/2005/Atom">
+  <entry>
+    <id>http://arxiv.org/abs/hep-th/9901001v2</id>
+    <title>Legacy Paper</title>
+    <summary>Legacy abstract.</summary>
+    <published>1999-01-10T00:00:00Z</published>
+    <updated>1999-01-12T00:00:00Z</updated>
+    <author><name>John Doe</name></author>
+    <category term="hep-th"/>
+    <link href="http://arxiv.org/abs/hep-th/9901001v2" rel="alternate" type="text/html"/>
+    <link href="http://arxiv.org/pdf/hep-th/9901001v2" rel="related" type="application/pdf"/>
+  </entry>
+</feed>`)
+
+	entries, err := parseFeed(payload)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(entries) != 1 {
+		t.Fatalf("expected 1 entry, got %d", len(entries))
+	}
+	paper := entries[0].toPaper()
+	if paper.ID != "hep-th/9901001" {
+		t.Fatalf("expected normalized legacy ID, got %q", paper.ID)
+	}
+	if paper.HTMLURL != "https://arxiv.org/html/hep-th/9901001" {
+		t.Fatalf("expected legacy html url, got %q", paper.HTMLURL)
+	}
+}
+
+func TestNormalizeArxivID(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		raw  string
+		want string
+	}{
+		{
+			name: "modern URL",
+			raw:  "http://arxiv.org/abs/1234.5678v2",
+			want: "1234.5678",
+		},
+		{
+			name: "legacy URL",
+			raw:  "http://arxiv.org/abs/hep-th/9901001v2",
+			want: "hep-th/9901001",
+		},
+		{
+			name: "legacy bare id",
+			raw:  "hep-th/9901001v3",
+			want: "hep-th/9901001",
+		},
+		{
+			name: "modern URL with query fragment",
+			raw:  "https://arxiv.org/abs/2501.01234v1?context=cs#frag",
+			want: "2501.01234",
+		},
+		{
+			name: "do not strip embedded v",
+			raw:  "http://arxiv.org/abs/cs.CV/0301001version",
+			want: "cs.CV/0301001version",
+		},
+	}
+
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got := normalizeArxivID(tc.raw)
+			if got != tc.want {
+				t.Fatalf("normalizeArxivID(%q): got %q, want %q", tc.raw, got, tc.want)
+			}
+		})
+	}
+}
+
 func searchOptions(query string, categories []string, dateFrom string, dateTo string) arxiv.SearchOptions {
 	return arxiv.SearchOptions{
 		Query:      query,

--- a/internal/sources/arxiv/impl/fetcher_test.go
+++ b/internal/sources/arxiv/impl/fetcher_test.go
@@ -128,6 +128,16 @@ func TestNormalizeArxivID(t *testing.T) {
 			raw:  "http://arxiv.org/abs/cs.CV/0301001version",
 			want: "cs.CV/0301001version",
 		},
+		{
+			name: "pdf URL",
+			raw:  "https://arxiv.org/pdf/2501.01234v2.pdf",
+			want: "2501.01234",
+		},
+		{
+			name: "pdf URL legacy",
+			raw:  "https://arxiv.org/pdf/hep-th/9901001v2.pdf",
+			want: "hep-th/9901001",
+		},
 	}
 
 	for _, tc := range tests {
@@ -139,6 +149,67 @@ func TestNormalizeArxivID(t *testing.T) {
 				t.Fatalf("normalizeArxivID(%q): got %q, want %q", tc.raw, got, tc.want)
 			}
 		})
+	}
+}
+
+func TestNormalizeAbsURL(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		raw  string
+		want string
+	}{
+		{
+			name: "bare modern id",
+			raw:  "2501.01234v2",
+			want: "https://arxiv.org/abs/2501.01234",
+		},
+		{
+			name: "bare legacy id",
+			raw:  "hep-th/9901001v3",
+			want: "https://arxiv.org/abs/hep-th/9901001",
+		},
+		{
+			name: "pdf URL becomes canonical abs URL",
+			raw:  "https://arxiv.org/pdf/2501.01234v2.pdf",
+			want: "https://arxiv.org/abs/2501.01234",
+		},
+		{
+			name: "abs URL normalized",
+			raw:  "http://arxiv.org/abs/1234.5678v2",
+			want: "https://arxiv.org/abs/1234.5678",
+		},
+	}
+
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got := normalizeAbsURL(tc.raw)
+			if got != tc.want {
+				t.Fatalf("normalizeAbsURL(%q): got %q, want %q", tc.raw, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestToPaper_BareIDBuildsCanonicalAbsAndFallbackPDF(t *testing.T) {
+	e := entry{
+		ID:      "2501.01234v2",
+		Title:   "Bare ID Paper",
+		Summary: "Abstract",
+	}
+	paper := e.toPaper()
+
+	if paper.ID != "2501.01234" {
+		t.Fatalf("expected normalized ID, got %q", paper.ID)
+	}
+	if paper.AbsURL != "https://arxiv.org/abs/2501.01234" {
+		t.Fatalf("expected canonical abs URL, got %q", paper.AbsURL)
+	}
+	if paper.PDFURL != "https://arxiv.org/pdf/2501.01234.pdf" {
+		t.Fatalf("expected canonical fallback pdf URL, got %q", paper.PDFURL)
 	}
 }
 

--- a/internal/sources/arxiv/impl/fetcher_test.go
+++ b/internal/sources/arxiv/impl/fetcher_test.go
@@ -1,0 +1,68 @@
+package impl
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/bakkerme/curator-ai/internal/sources/arxiv"
+)
+
+func TestBuildSearchQuery(t *testing.T) {
+	query, err := buildSearchQuery(searchOptions("test query", []string{"cs.CL", "cs.IR"}, "2024-01-01", "2024-01-31"))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !strings.Contains(query, "all:\"test query\"") {
+		t.Fatalf("expected query clause, got %q", query)
+	}
+	if !strings.Contains(query, "cat:cs.CL") || !strings.Contains(query, "cat:cs.IR") {
+		t.Fatalf("expected category clause, got %q", query)
+	}
+	if !strings.Contains(query, "submittedDate:[") {
+		t.Fatalf("expected date clause, got %q", query)
+	}
+}
+
+func TestParseFeed(t *testing.T) {
+	payload := []byte(`<?xml version="1.0" encoding="UTF-8"?>
+<feed xmlns="http://www.w3.org/2005/Atom">
+  <entry>
+    <id>http://arxiv.org/abs/1234.5678v2</id>
+    <title>Sample Paper</title>
+    <summary>Abstract text.</summary>
+    <published>2024-01-10T00:00:00Z</published>
+    <updated>2024-01-12T00:00:00Z</updated>
+    <author><name>Jane Doe</name></author>
+    <category term="cs.CL"/>
+    <link href="http://arxiv.org/abs/1234.5678v2" rel="alternate" type="text/html"/>
+    <link href="http://arxiv.org/pdf/1234.5678v2" rel="related" type="application/pdf"/>
+  </entry>
+</feed>`)
+
+	entries, err := parseFeed(payload)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(entries) != 1 {
+		t.Fatalf("expected 1 entry, got %d", len(entries))
+	}
+	paper := entries[0].toPaper()
+	if paper.ID != "1234.5678" {
+		t.Fatalf("expected normalized ID, got %q", paper.ID)
+	}
+	if paper.PDFURL == "" {
+		t.Fatalf("expected pdf url")
+	}
+	if paper.HTMLURL == "" {
+		t.Fatalf("expected html url")
+	}
+}
+
+func searchOptions(query string, categories []string, dateFrom string, dateTo string) arxiv.SearchOptions {
+	return arxiv.SearchOptions{
+		Query:      query,
+		Categories: categories,
+		DateFrom:   dateFrom,
+		DateTo:     dateTo,
+	}
+}

--- a/internal/sources/jina/impl/reader.go
+++ b/internal/sources/jina/impl/reader.go
@@ -16,7 +16,7 @@ import (
 )
 
 const defaultBaseURL = "https://r.jina.ai/"
-const tokenBudget = "15000" // 10k tokens
+const defaultTokenBudget = 15000 // 15k tokens
 
 type Reader struct {
 	client      *http.Client
@@ -63,6 +63,11 @@ func (r *Reader) Read(ctx context.Context, urlStr string, options jina.ReadOptio
 		return "", fmt.Errorf("jina: url is blocklisted")
 	}
 
+	tokenBudget := options.TokenBudget
+	if tokenBudget <= 0 {
+		tokenBudget = defaultTokenBudget
+	}
+
 	retainImages := strings.TrimSpace(options.RetainImages)
 	if retainImages == "" {
 		retainImages = "none"
@@ -85,7 +90,7 @@ func (r *Reader) Read(ctx context.Context, urlStr string, options jina.ReadOptio
 		req.Header.Set("Content-Type", "application/json")
 		req.Header.Set("X-Retain-Images", retainImages)
 		req.Header.Set("User-Agent", r.userAgent)
-		req.Header.Set("X-Token-Budget", tokenBudget) // 10k tokens
+		req.Header.Set("X-Token-Budget", fmt.Sprintf("%d", tokenBudget))
 
 		resp, err := r.client.Do(req)
 		if err != nil {

--- a/internal/sources/jina/jina.go
+++ b/internal/sources/jina/jina.go
@@ -6,6 +6,7 @@ import "context"
 type ReadOptions struct {
 	// RetainImages controls the "X-Retain-Images" header. Defaults to "none".
 	RetainImages string
+	TokenBudget int
 }
 
 // Reader fetches a URL via Jina Reader and returns markdown.


### PR DESCRIPTION
### Motivation
- Provide a ready-to-use Curator Document for the new arXiv source so flows can be quickly validated and manual end-to-end checks performed.

### Description
- Add a sample curator document at `curator-docs/testing-docs/arxiv.yaml` that configures a cron-triggered workflow using the `arxiv` source and an email output.
- Add arXiv support across the codebase: `ArxivSource` and `ArxivChunkingConfig` in `internal/config/schema.go`, validation and flow parsing wiring for arXiv, and factory wiring (`NewArxivSource` and default `ArxivFetcher`) in `internal/runner/factory/factory.go`.
- Implement the arXiv source processor and chunking: `internal/processors/source/arxiv.go`, `internal/processors/source/arxiv_chunk.go`, and corresponding chunking tests.
- Implement arXiv API client and normalization logic: `internal/sources/arxiv` and `internal/sources/arxiv/impl/fetcher.go` with unit tests for query building and feed parsing.

### Testing
- arXiv-related unit tests were added (schema, fetcher, chunking) alongside the source implementation in the codebase; those tests were included in earlier work and reported passing when last executed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698698fac048832c8ab4b3974d0528dc)