### PR TITLE
Fix Docker GOARCH fallback for host-compatible builds

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,8 @@
 ARG GO_VERSION=1.25.5
 
 FROM golang:${GO_VERSION} AS build
-ARG TARGETOS=linux
-ARG TARGETARCH=amd64
+ARG TARGETOS
+ARG TARGETARCH
 WORKDIR /src
 
 COPY go.mod go.sum ./
@@ -13,7 +13,7 @@ COPY . .
 
 # Build a small, static-ish binary (CGO disabled) suitable for distroless.
 RUN --mount=type=cache,target=/root/.cache/go-build \
-    CGO_ENABLED=0 GOOS=${TARGETOS} GOARCH=${TARGETARCH} \
+    CGO_ENABLED=0 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH:-$(go env GOHOSTARCH)} \
     go build -trimpath -ldflags="-s -w" -o /out/curator ./cmd/curator
 
 FROM debian:bookworm-slim AS runtime


### PR DESCRIPTION
### Motivation
- Prevent local/non-buildx Docker builds from producing binaries for the wrong architecture (which can cause `exec format error` on aarch64/other hosts) by ensuring the build defaults to the host Go architecture when no explicit target is provided.

### Description
- Update `Dockerfile` to remove hard-coded `TARGETOS`/`TARGETARCH` defaults and use shell fallbacks in the `go build` step: `GOOS=${TARGETOS:-linux}` and `GOARCH=${TARGETARCH:-$(go env GOHOSTARCH)}`.

### Testing
- Ran `go test ./... -timeout 60s` and `go vet ./...`, and both completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69943ff7fd00832c9d6d11d35dbcb962)