### PR TITLE
Add configurable thinking toggle for OpenAI-compatible chat completions

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ go run ./cmd/curator -config curator.yaml -run-once
 - `OPENAI_BASE_URL` (optional for OpenAI-compatible endpoints)
 - `OPENAI_MODEL` (optional, default: `gpt-4o-mini`)
 - `OPENAI_TEMPERATURE` (optional, default: provider default; overridden by per-processor YAML `temperature`)
+- `OPENAI_ENABLE_THINKING` (optional, default: `true`; set `false` for providers/models such as Qwen 3.5 when you want to disable thinking/reasoning mode)
 
 ### Email Output (SMTP)
 - `SMTP_HOST` (required unless set in YAML)

--- a/internal/config/env.go
+++ b/internal/config/env.go
@@ -30,7 +30,10 @@ type OpenAIEnvConfig struct {
 	BaseURL     string
 	Model       string
 	Temperature *float64
-	OTel        OpenAIOTelEnvConfig
+	// EnableThinking toggles provider-specific reasoning/thinking features for
+	// OpenAI-compatible endpoints that support chat_template_kwargs.enable_thinking.
+	EnableThinking bool
+	OTel           OpenAIOTelEnvConfig
 }
 
 type OpenAIOTelEnvConfig struct {
@@ -113,10 +116,11 @@ func LoadEnv() EnvConfig {
 		AllowPartialSourceErrors: envBool("ALLOW_PARTIAL_SOURCE_ERRORS", false),
 		SessionID:                strings.TrimSpace(envString("SESSION_ID", "")),
 		OpenAI: OpenAIEnvConfig{
-			APIKey:      strings.TrimSpace(envString("OPENAI_API_KEY", "")),
-			BaseURL:     strings.TrimSpace(envString("OPENAI_BASE_URL", "")),
-			Model:       openAIModel,
-			Temperature: envFloatPtr("OPENAI_TEMPERATURE"),
+			APIKey:         strings.TrimSpace(envString("OPENAI_API_KEY", "")),
+			BaseURL:        strings.TrimSpace(envString("OPENAI_BASE_URL", "")),
+			Model:          openAIModel,
+			Temperature:    envFloatPtr("OPENAI_TEMPERATURE"),
+			EnableThinking: envBool("OPENAI_ENABLE_THINKING", true),
 			OTel: OpenAIOTelEnvConfig{
 				Enabled:       envBool("OTEL_OPENAI_ENABLED", true),
 				CaptureBodies: envBool("OTEL_CAPTURE_OPENAI_BODIES", false),

--- a/internal/config/env_test.go
+++ b/internal/config/env_test.go
@@ -27,3 +27,21 @@ func TestLoadEnv_RedditProxyConfigured(t *testing.T) {
 		t.Fatalf("unexpected REDDIT_PROXY_URL: %q", env.Reddit.ProxyURL)
 	}
 }
+
+func TestLoadEnv_OpenAIEnableThinkingDefault(t *testing.T) {
+	t.Setenv("OPENAI_ENABLE_THINKING", "")
+
+	env := LoadEnv()
+	if !env.OpenAI.EnableThinking {
+		t.Fatalf("expected OPENAI_ENABLE_THINKING default to be true")
+	}
+}
+
+func TestLoadEnv_OpenAIEnableThinkingConfigured(t *testing.T) {
+	t.Setenv("OPENAI_ENABLE_THINKING", "false")
+
+	env := LoadEnv()
+	if env.OpenAI.EnableThinking {
+		t.Fatalf("expected OPENAI_ENABLE_THINKING to be false")
+	}
+}

--- a/internal/llm/llm.go
+++ b/internal/llm/llm.go
@@ -36,6 +36,9 @@ type ChatRequest struct {
 	Messages    []Message
 	Temperature *float64
 	MaxTokens   int
+	// EnableThinking controls provider-specific reasoning/thinking mode toggles
+	// for OpenAI-compatible chat completion endpoints.
+	EnableThinking *bool
 }
 
 type ChatResponse struct {

--- a/internal/llm/openai/client.go
+++ b/internal/llm/openai/client.go
@@ -3,7 +3,6 @@ package openai
 import (
 	"context"
 	"fmt"
-	"os"
 
 	openai "github.com/openai/openai-go"
 	"github.com/openai/openai-go/option"
@@ -17,8 +16,9 @@ import (
 )
 
 type Client struct {
-	client         openai.Client
-	enableThinking bool
+	client              openai.Client
+	enableThinking      bool
+	hasCustomBaseURL    bool
 }
 
 func NewClient(cfg config.OpenAIEnvConfig, opts ...option.RequestOption) *Client {
@@ -33,7 +33,11 @@ func NewClient(cfg config.OpenAIEnvConfig, opts ...option.RequestOption) *Client
 		options = append(options, option.WithMiddleware(openAIMiddleware(cfg.OTel)))
 	}
 	options = append(options, opts...)
-	return &Client{client: openai.NewClient(options...), enableThinking: cfg.EnableThinking}
+	return &Client{
+		client:           openai.NewClient(options...),
+		enableThinking:   cfg.EnableThinking,
+		hasCustomBaseURL: cfg.BaseURL != "",
+	}
 }
 
 func (c *Client) ChatCompletion(ctx context.Context, request llm.ChatRequest) (llm.ChatResponse, error) {
@@ -105,7 +109,7 @@ func (c *Client) ChatCompletion(ctx context.Context, request llm.ChatRequest) (l
 		enableThinking = *request.EnableThinking
 	}
 	// Only include chat_template_kwargs when using a custom OpenAI base URL.
-	if baseURL := os.Getenv("OPENAI_BASE_URL"); baseURL != "" {
+	if c.hasCustomBaseURL {
 		requestOptions = append(requestOptions,
 			option.WithJSONSet("chat_template_kwargs", map[string]bool{"enable_thinking": enableThinking}),
 		)

--- a/internal/llm/openai/client.go
+++ b/internal/llm/openai/client.go
@@ -16,7 +16,8 @@ import (
 )
 
 type Client struct {
-	client openai.Client
+	client         openai.Client
+	enableThinking bool
 }
 
 func NewClient(cfg config.OpenAIEnvConfig, opts ...option.RequestOption) *Client {
@@ -31,7 +32,7 @@ func NewClient(cfg config.OpenAIEnvConfig, opts ...option.RequestOption) *Client
 		options = append(options, option.WithMiddleware(openAIMiddleware(cfg.OTel)))
 	}
 	options = append(options, opts...)
-	return &Client{client: openai.NewClient(options...)}
+	return &Client{client: openai.NewClient(options...), enableThinking: cfg.EnableThinking}
 }
 
 func (c *Client) ChatCompletion(ctx context.Context, request llm.ChatRequest) (llm.ChatResponse, error) {
@@ -97,7 +98,16 @@ func (c *Client) ChatCompletion(ctx context.Context, request llm.ChatRequest) (l
 		params.MaxTokens = openai.Int(int64(request.MaxTokens))
 	}
 
-	response, err := c.client.Chat.Completions.New(ctx, params)
+	requestOptions := []option.RequestOption{}
+	enableThinking := c.enableThinking
+	if request.EnableThinking != nil {
+		enableThinking = *request.EnableThinking
+	}
+	requestOptions = append(requestOptions,
+		option.WithJSONSet("chat_template_kwargs", map[string]bool{"enable_thinking": enableThinking}),
+	)
+
+	response, err := c.client.Chat.Completions.New(ctx, params, requestOptions...)
 	if err != nil {
 		span.RecordError(err)
 		span.SetStatus(codes.Error, err.Error())

--- a/internal/llm/openai/client.go
+++ b/internal/llm/openai/client.go
@@ -3,6 +3,7 @@ package openai
 import (
 	"context"
 	"fmt"
+	"os"
 
 	openai "github.com/openai/openai-go"
 	"github.com/openai/openai-go/option"
@@ -103,9 +104,12 @@ func (c *Client) ChatCompletion(ctx context.Context, request llm.ChatRequest) (l
 	if request.EnableThinking != nil {
 		enableThinking = *request.EnableThinking
 	}
-	requestOptions = append(requestOptions,
-		option.WithJSONSet("chat_template_kwargs", map[string]bool{"enable_thinking": enableThinking}),
-	)
+	// Only include chat_template_kwargs when using a custom OpenAI base URL.
+	if baseURL := os.Getenv("OPENAI_BASE_URL"); baseURL != "" {
+		requestOptions = append(requestOptions,
+			option.WithJSONSet("chat_template_kwargs", map[string]bool{"enable_thinking": enableThinking}),
+		)
+	}
 
 	response, err := c.client.Chat.Completions.New(ctx, params, requestOptions...)
 	if err != nil {

--- a/internal/llm/openai/client_test.go
+++ b/internal/llm/openai/client_test.go
@@ -1,0 +1,95 @@
+package openai
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/bakkerme/curator-ai/internal/config"
+	"github.com/bakkerme/curator-ai/internal/llm"
+)
+
+func TestChatCompletion_SendsThinkingToggleFromEnvDefault(t *testing.T) {
+	t.Parallel()
+
+	requestBody := make(chan map[string]any, 1)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		defer r.Body.Close()
+		body, _ := io.ReadAll(r.Body)
+		decoded := map[string]any{}
+		_ = json.Unmarshal(body, &decoded)
+		requestBody <- decoded
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"id":"x","object":"chat.completion","created":1,"model":"qwen","choices":[{"index":0,"message":{"role":"assistant","content":"ok"},"finish_reason":"stop"}]}`))
+	}))
+	defer server.Close()
+
+	client := NewClient(config.OpenAIEnvConfig{BaseURL: server.URL, APIKey: "test", EnableThinking: false})
+	_, err := client.ChatCompletion(context.Background(), llm.ChatRequest{
+		Model:    "Qwen/Qwen3.5-35B-A3B",
+		Messages: []llm.Message{{Role: llm.RoleUser, Content: "hi"}},
+	})
+	if err != nil {
+		t.Fatalf("ChatCompletion returned error: %v", err)
+	}
+
+	select {
+	case got := <-requestBody:
+		chatTemplate, ok := got["chat_template_kwargs"].(map[string]any)
+		if !ok {
+			t.Fatalf("expected chat_template_kwargs object in request body")
+		}
+		if enabled, ok := chatTemplate["enable_thinking"].(bool); !ok || enabled {
+			t.Fatalf("expected enable_thinking=false, got %#v", chatTemplate["enable_thinking"])
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatalf("timed out waiting for request body")
+	}
+}
+
+func TestChatCompletion_RequestOverrideThinkingToggle(t *testing.T) {
+	t.Parallel()
+
+	var (
+		mu   sync.Mutex
+		body map[string]any
+	)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		defer r.Body.Close()
+		raw, _ := io.ReadAll(r.Body)
+		decoded := map[string]any{}
+		_ = json.Unmarshal(raw, &decoded)
+		mu.Lock()
+		body = decoded
+		mu.Unlock()
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"id":"x","object":"chat.completion","created":1,"model":"qwen","choices":[{"index":0,"message":{"role":"assistant","content":"ok"},"finish_reason":"stop"}]}`))
+	}))
+	defer server.Close()
+
+	client := NewClient(config.OpenAIEnvConfig{BaseURL: server.URL, APIKey: "test", EnableThinking: true})
+	disableThinking := false
+	_, err := client.ChatCompletion(context.Background(), llm.ChatRequest{
+		Model:          "Qwen/Qwen3.5-35B-A3B",
+		Messages:       []llm.Message{{Role: llm.RoleUser, Content: "hi"}},
+		EnableThinking: &disableThinking,
+	})
+	if err != nil {
+		t.Fatalf("ChatCompletion returned error: %v", err)
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	chatTemplate, ok := body["chat_template_kwargs"].(map[string]any)
+	if !ok {
+		t.Fatalf("expected chat_template_kwargs object in request body")
+	}
+	if enabled, ok := chatTemplate["enable_thinking"].(bool); !ok || enabled {
+		t.Fatalf("expected enable_thinking=false, got %#v", chatTemplate["enable_thinking"])
+	}
+}


### PR DESCRIPTION
## Summary
- add `OPENAI_ENABLE_THINKING` to `internal/config.OpenAIEnvConfig` and wire it through `LoadEnv` (default `true`)
- extend `llm.ChatRequest` with optional `EnableThinking` override
- update OpenAI client to inject `chat_template_kwargs.enable_thinking` on each chat completion request using the configured default (or per-request override)
- document the new env var in `README.md`
- add tests for env parsing and request payload behavior in `internal/config/env_test.go` and new `internal/llm/openai/client_test.go`

## Why
This enables compatibility with providers/models (e.g. Qwen 3.5) that need thinking mode explicitly disabled via:
`chat_template_kwargs: { enable_thinking: false }`.

## Validation
- `go test ./internal/config -run OpenAIEnableThinking -count=1`
- `go test ./internal/llm/openai -run ThinkingToggle -count=1`
- `go vet ./internal/config ./internal/llm/openai`
- `golangci-lint run` currently fails in this environment because the installed binary was built with Go 1.24 while the project targets Go 1.25.5.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b3e9d8ac8c832c8c0f2ec85734a960)